### PR TITLE
Implement Bid struct & blindbid score generation fns & gadgets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: rust
+sudo: true
+cache: cargo
+os:
+  - linux
+
+matrix:
+  fast_finish: false
+  include:
+  - rust: stable
+    script:
+      # Run tests/builds
+      - cargo check
+      - cargo build --release --verbose --all
+      - cargo test --release --verbose --all
+      
+  
+  - rust: nightly
+    script:
+      # Run tests/builds
+      - cargo check
+      - cargo build --release --verbose --all
+      - cargo test --release --verbose --all
+
+
+# Send a notification to the Dusk build Status Telegram channel once the CI build completes
+after_script:
+  - bash <(curl -s https://raw.githubusercontent.com/dusk-network/tools/master/bash/telegram_ci_notifications.sh)
+
+after_success:
+# Upload docs
+- |
+    if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+      cargo doc --no-deps &&
+      echo "<meta http-equiv=refresh content=0;url=dusk_blindbid/index.html>" > target/doc/index.html &&
+      git clone https://github.com/davisp/ghp-import.git &&
+      ./ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&
+      echo "Uploaded documentation"
+    fi
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2018"
 
 
 [dependencies]
+dusk-plonk = "0.1.0"
+dusk-bls12_381 = "0.1.0"
+hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ dusk-plonk = "0.1.0"
 dusk-bls12_381 = "0.1.0"
 hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}
+
+[dev-dependencies]
+merlin = "2.0.0"
+rand = "0.7.3"

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -1,7 +1,9 @@
 //! Bid data structure
 //!
 
+use crate::score_gen::score::compute_score;
 use dusk_bls12_381::{G1Affine, Scalar};
+use poseidon252::sponge::sponge::sponge_hash;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Bid {
@@ -20,17 +22,80 @@ pub struct Bid {
     //
     // i (One time identity of the prover)
     pub(crate) prover_id: Option<Scalar>,
-    // q (Score)
+    // q (Score of the bid)
     pub(crate) score: Option<Scalar>,
     //
     // Private Inputs
     //
     // v
-    pub(crate) bid_value: Scalar,
+    pub(crate) value: Scalar,
     // r
-    pub(crate) bid_randomness: Scalar,
+    pub(crate) randomness: Scalar,
     // k
     pub(crate) secret_k: Scalar,
     // R = r * G
     pub(crate) pk: G1Affine,
+}
+
+impl Default for Bid {
+    fn default() -> Self {
+        Bid {
+            bid_tree_root: Scalar::zero(),
+            consensus_round_seed: Scalar::zero(),
+            latest_consensus_round: Scalar::zero(),
+            latest_consensus_step: Scalar::zero(),
+            prover_id: None,
+            score: None,
+            value: Scalar::zero(),
+            randomness: Scalar::zero(),
+            secret_k: Scalar::zero(),
+            pk: G1Affine::default(),
+        }
+    }
+}
+
+impl Bid {
+    pub fn new(
+        bid_tree_root: Scalar,
+        consensus_round_seed: Scalar,
+        latest_consensus_round: Scalar,
+        latest_consensus_step: Scalar,
+        bid_value: Scalar,
+        bid_randomness: Scalar,
+        secret_k: Scalar,
+        pk: G1Affine,
+    ) -> Self {
+        // Initialize the Bid with the fields we were provided.
+        let mut bid = Bid {
+            bid_tree_root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+            prover_id: None,
+            score: None,
+            value: bid_value,
+            randomness: bid_randomness,
+            secret_k,
+            pk,
+        };
+        // Compute and add to the Bid the `prover_id`.
+        bid.generate_prover_id();
+        // Compute score and append it to the Bid.
+        bid.score = Some(compute_score(&bid));
+
+        bid
+    }
+
+    /// One-time prover-id is stated to be H(secret_k, sigma^s, k^t, k^s).
+    ///
+    /// The function performs the sponge_hash techniqe using poseidon to
+    /// get the one-time prover_id and sets it in the Bid.
+    pub(crate) fn generate_prover_id(&mut self) {
+        self.prover_id = Some(sponge_hash(&[
+            self.secret_k,
+            self.consensus_round_seed,
+            self.latest_consensus_round,
+            self.latest_consensus_step,
+        ]));
+    }
 }

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -1,0 +1,36 @@
+//! Bid data structure
+//!
+
+use dusk_bls12_381::{G1Affine, Scalar};
+
+#[derive(Copy, Clone, Debug)]
+pub struct Bid {
+    // Pub Inputs
+    //
+    // B^R
+    pub(crate) bid_tree_root: Scalar,
+    // sigma^s
+    pub(crate) consensus_round_seed: Scalar,
+    // k^r
+    pub(crate) latest_consensus_round: Scalar,
+    // k^s
+    pub(crate) latest_consensus_step: Scalar,
+    //
+    // Public Outputs
+    //
+    // i (One time identity of the prover)
+    pub(crate) prover_id: Option<Scalar>,
+    // q (Score)
+    pub(crate) score: Option<Scalar>,
+    //
+    // Private Inputs
+    //
+    // v
+    pub(crate) bid_value: Scalar,
+    // r
+    pub(crate) bid_randomness: Scalar,
+    // k
+    pub(crate) secret_k: Scalar,
+    // R = r * G
+    pub(crate) pk: G1Affine,
+}

--- a/src/bid/mod.rs
+++ b/src/bid/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod bid;
+pub use bid::Bid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+//! BlindBid impl
+
+pub mod bid;
+pub mod proof;
+pub mod score_gen;

--- a/src/proof/blindbid_proof.rs
+++ b/src/proof/blindbid_proof.rs
@@ -1,0 +1,9 @@
+//! BlindBidProof module.
+//!
+
+use crate::bid::Bid;
+use dusk_plonk::constraint_system::StandardComposer;
+
+pub fn blind_bid_proof(composer: &mut StandardComposer, bid: &Bid) {
+    unimplemented!()
+}

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -1,0 +1,1 @@
+pub mod blindbid_proof;

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -1,0 +1,1 @@
+pub mod score;

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -1,0 +1,98 @@
+//! Score generation
+
+use crate::bid::Bid;
+use dusk_bls12_381::Scalar;
+use dusk_plonk::constraint_system::{StandardComposer, Variable};
+use poseidon252::sponge::*;
+
+pub fn compute_score(bid: &Bid) -> Scalar {
+    // Compute `y` where `y = H(secret_k, Merkle_root, consensus_round_seed, latest_consensus_round, latest_consensus_step)`.
+    let y = sponge::sponge_hash(&[
+        bid.secret_k,
+        bid.bid_tree_root,
+        bid.consensus_round_seed,
+        bid.latest_consensus_round,
+        bid.latest_consensus_step,
+    ]);
+    // Compute y' and 1/y'.
+    let (_, inv_y_prime) = compute_y_primes(y);
+    // Return the score `q = v*2^128 / y'`.
+    bid.bid_value * Scalar::from(2u64).pow(&[128, 0, 0, 0]) * inv_y_prime
+}
+
+pub fn compute_score_gadget(
+    composer: &mut StandardComposer,
+    bid: &Bid,
+    bid_value: Variable,
+    secret_k: Variable,
+    bid_tree_root: Variable,
+    consensus_round_seed: Variable,
+    latest_consensus_round: Variable,
+    latest_consensus_step: Variable,
+) -> Variable {
+    // Compute `y` where `y = H(secret_k, Merkle_root, consensus_round_seed, latest_consensus_round, latest_consensus_step)`.
+    // This is done in ZK using the sponge hash gadget.
+    let y = sponge::sponge_hash_gadget(
+        composer,
+        &[
+            secret_k,
+            bid_tree_root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        ],
+    );
+    // We also need to compute the sponge hash with the scalars since we need to prove the correctness of the inverse
+    // of y'.
+    let scalar_y = sponge::sponge_hash(&[
+        bid.secret_k,
+        bid.bid_tree_root,
+        bid.consensus_round_seed,
+        bid.latest_consensus_round,
+        bid.latest_consensus_step,
+    ]);
+    // Compute 1/y' where `y' = y & 2^129 -1`. This needs to be done for `Scalar` and `Variable` backends
+    // to then assert that the inverse is correct.
+    // Compute y' and 1/y'.
+    let (_, inv_y_prime_scalar) = compute_y_primes(scalar_y);
+
+    // Compute y' as a Variable.
+    let y_prime_var = {
+        let truncate_val =
+            composer.add_input(Scalar::from(2u64).pow(&[129, 0, 0, 0]) - Scalar::one());
+        composer.logic_and_gate(y, truncate_val, 256)
+    };
+
+    // Generate a Variable for 1/y'.
+    let supposed_inv_y_prime = composer.add_input(inv_y_prime_scalar);
+    // Check that 1/y' is indeed the inverse of y'.
+    // To do that, we multiply the real 1/y' and the computed y' and subtract one.
+    // This is indeed the constraint that verifies the integrity of the inverse.
+    //
+    // We don't need the input since it should be 0. If it is not, the verification process
+    // will fail.
+    composer.mul(
+        Scalar::one(),
+        y_prime_var,
+        supposed_inv_y_prime,
+        -Scalar::one(),
+        Scalar::zero(),
+    );
+    // Return the score `q = v*2^128 / y'`.
+    composer.mul(
+        Scalar::from(2u64).pow(&[128, 0, 0, 0]),
+        bid_value,
+        supposed_inv_y_prime,
+        Scalar::zero(),
+        Scalar::zero(),
+    )
+}
+
+// Given the y parameter, return the y' and it's inverse value.
+fn compute_y_primes(y: Scalar) -> (Scalar, Scalar) {
+    // Compute y'
+    let y_prime = y & (Scalar::from(2u64).pow(&[129, 0, 0, 0]) - Scalar::one());
+    // Compute 1/y' where `y' = y & 2^129 -1`
+    let inv_y_prime = y.invert().unwrap();
+    (y_prime, inv_y_prime)
+}

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -17,7 +17,7 @@ pub fn compute_score(bid: &Bid) -> Scalar {
     // Compute y' and 1/y'.
     let (_, inv_y_prime) = compute_y_primes(y);
     // Return the score `q = v*2^128 / y'`.
-    bid.bid_value * Scalar::from(2u64).pow(&[128, 0, 0, 0]) * inv_y_prime
+    bid.value * Scalar::from(2u64).pow(&[128, 0, 0, 0]) * inv_y_prime
 }
 
 pub fn compute_score_gadget(


### PR DESCRIPTION
- Added plonk, Poseidon and bls12_381 as dependencies
in `Cargo.toml`.
- Generate `Bid` structure which contains the needed fields
to generate scores and blindbidproofs.

Closes #1

- The Bids need to be capable of self-generating a Score
that is unique for them. This score can't be known "a-priori".

- Add score generation function for `Scalar`.
- Add score generation gadget for `Variable`. This is indeed
proving that the score is generated correctly.
- Add tests that prove that both impls provide the same score.

Both functions return the generated score as `Scalar` or
`Variable` depending on what the user wants.

Closes #6