### PR TITLE
Bid encoding implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: rust
+sudo: true
+cache: cargo
+os:
+  - linux
+
+matrix:
+  fast_finish: false
+  include:
+  - rust: stable
+    script:
+      # Run tests/builds
+      - cargo check
+      - cargo build --release --verbose --all
+      - cargo test --release --verbose --all
+      
+  
+  - rust: nightly
+    script:
+      # Run tests/builds
+      - cargo check
+      - cargo build --release --verbose --all
+      - cargo test --release --verbose --all
+
+
+# Send a notification to the Dusk build Status Telegram channel once the CI build completes
+after_script:
+  - bash <(curl -s https://raw.githubusercontent.com/dusk-network/tools/master/bash/telegram_ci_notifications.sh)
+
+after_success:
+# Upload docs
+- |
+    if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+      cargo doc --no-deps &&
+      echo "<meta http-equiv=refresh content=0;url=dusk_blindbid/index.html>" > target/doc/index.html &&
+      git clone https://github.com/davisp/ghp-import.git &&
+      ./ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&
+      echo "Uploaded documentation"
+    fi
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ dusk-plonk = "0.1.0"
 dusk-bls12_381 = "0.1.0"
 hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}
+failure = "0.1.7"
+kelvin = "0.13.0"
+jubjub = {git = "https://github.com/dusk-network/jubjub", branch = "master"}
 
 [dev-dependencies]
 merlin = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2018"
 
 
 [dependencies]
+dusk-plonk = "0.1.0"
+dusk-bls12_381 = "0.1.0"
+hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ dusk-plonk = "0.1.0"
 dusk-bls12_381 = "0.1.0"
 hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}
+
+[dev-dependencies]
+merlin = "2.0.0"
+rand = "0.7.3"

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -2,7 +2,8 @@
 //!
 
 use crate::score_gen::score::compute_score;
-use dusk_bls12_381::{G1Affine, Scalar};
+use dusk_bls12_381::Scalar;
+use jubjub::{AffinePoint, Scalar as JubJubScalar};
 use poseidon252::sponge::sponge::sponge_hash;
 
 #[derive(Copy, Clone, Debug)]
@@ -32,9 +33,9 @@ pub struct Bid {
     // r
     pub(crate) randomness: Scalar,
     // k
-    pub(crate) secret_k: Scalar,
+    pub(crate) secret_k: JubJubScalar,
     // R = r * G
-    pub(crate) pk: G1Affine,
+    pub(crate) pk: AffinePoint,
 }
 
 impl Default for Bid {
@@ -48,8 +49,8 @@ impl Default for Bid {
             score: None,
             value: Scalar::zero(),
             randomness: Scalar::zero(),
-            secret_k: Scalar::zero(),
-            pk: G1Affine::default(),
+            secret_k: JubJubScalar::zero(),
+            pk: AffinePoint::default(),
         }
     }
 }
@@ -62,8 +63,8 @@ impl Bid {
         latest_consensus_step: Scalar,
         bid_value: Scalar,
         bid_randomness: Scalar,
-        secret_k: Scalar,
-        pk: G1Affine,
+        secret_k: JubJubScalar,
+        pk: AffinePoint,
     ) -> Self {
         // Initialize the Bid with the fields we were provided.
         let mut bid = Bid {
@@ -92,7 +93,7 @@ impl Bid {
     /// get the one-time prover_id and sets it in the Bid.
     pub(crate) fn generate_prover_id(&mut self) {
         self.prover_id = Some(sponge_hash(&[
-            self.secret_k,
+            Scalar::from_bytes(&self.secret_k.to_bytes()).unwrap(),
             self.consensus_round_seed,
             self.latest_consensus_round,
             self.latest_consensus_step,

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -6,7 +6,7 @@ use dusk_bls12_381::Scalar;
 use jubjub::{AffinePoint, Scalar as JubJubScalar};
 use poseidon252::sponge::sponge::sponge_hash;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Bid {
     // Pub Inputs
     //
@@ -36,23 +36,6 @@ pub struct Bid {
     pub(crate) secret_k: Scalar,
     // R = r * G
     pub(crate) pk: AffinePoint,
-}
-
-impl Default for Bid {
-    fn default() -> Self {
-        Bid {
-            bid_tree_root: Scalar::zero(),
-            consensus_round_seed: Scalar::zero(),
-            latest_consensus_round: Scalar::zero(),
-            latest_consensus_step: Scalar::zero(),
-            prover_id: None,
-            score: None,
-            value: JubJubScalar::zero(),
-            randomness: JubJubScalar::zero(),
-            secret_k: Scalar::zero(),
-            pk: AffinePoint::default(),
-        }
-    }
 }
 
 impl Bid {

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -1,7 +1,9 @@
 //! Bid data structure
 //!
 
+use crate::score_gen::score::compute_score;
 use dusk_bls12_381::{G1Affine, Scalar};
+use poseidon252::sponge::sponge::sponge_hash;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Bid {
@@ -20,17 +22,80 @@ pub struct Bid {
     //
     // i (One time identity of the prover)
     pub(crate) prover_id: Option<Scalar>,
-    // q (Score)
+    // q (Score of the bid)
     pub(crate) score: Option<Scalar>,
     //
     // Private Inputs
     //
     // v
-    pub(crate) bid_value: Scalar,
+    pub(crate) value: Scalar,
     // r
-    pub(crate) bid_randomness: Scalar,
+    pub(crate) randomness: Scalar,
     // k
     pub(crate) secret_k: Scalar,
     // R = r * G
     pub(crate) pk: G1Affine,
+}
+
+impl Default for Bid {
+    fn default() -> Self {
+        Bid {
+            bid_tree_root: Scalar::zero(),
+            consensus_round_seed: Scalar::zero(),
+            latest_consensus_round: Scalar::zero(),
+            latest_consensus_step: Scalar::zero(),
+            prover_id: None,
+            score: None,
+            value: Scalar::zero(),
+            randomness: Scalar::zero(),
+            secret_k: Scalar::zero(),
+            pk: G1Affine::default(),
+        }
+    }
+}
+
+impl Bid {
+    pub fn new(
+        bid_tree_root: Scalar,
+        consensus_round_seed: Scalar,
+        latest_consensus_round: Scalar,
+        latest_consensus_step: Scalar,
+        bid_value: Scalar,
+        bid_randomness: Scalar,
+        secret_k: Scalar,
+        pk: G1Affine,
+    ) -> Self {
+        // Initialize the Bid with the fields we were provided.
+        let mut bid = Bid {
+            bid_tree_root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+            prover_id: None,
+            score: None,
+            value: bid_value,
+            randomness: bid_randomness,
+            secret_k,
+            pk,
+        };
+        // Compute and add to the Bid the `prover_id`.
+        bid.generate_prover_id();
+        // Compute score and append it to the Bid.
+        bid.score = Some(compute_score(&bid));
+
+        bid
+    }
+
+    /// One-time prover-id is stated to be H(secret_k, sigma^s, k^t, k^s).
+    ///
+    /// The function performs the sponge_hash techniqe using poseidon to
+    /// get the one-time prover_id and sets it in the Bid.
+    pub(crate) fn generate_prover_id(&mut self) {
+        self.prover_id = Some(sponge_hash(&[
+            self.secret_k,
+            self.consensus_round_seed,
+            self.latest_consensus_round,
+            self.latest_consensus_step,
+        ]));
+    }
 }

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -1,0 +1,36 @@
+//! Bid data structure
+//!
+
+use dusk_bls12_381::{G1Affine, Scalar};
+
+#[derive(Copy, Clone, Debug)]
+pub struct Bid {
+    // Pub Inputs
+    //
+    // B^R
+    pub(crate) bid_tree_root: Scalar,
+    // sigma^s
+    pub(crate) consensus_round_seed: Scalar,
+    // k^r
+    pub(crate) latest_consensus_round: Scalar,
+    // k^s
+    pub(crate) latest_consensus_step: Scalar,
+    //
+    // Public Outputs
+    //
+    // i (One time identity of the prover)
+    pub(crate) prover_id: Option<Scalar>,
+    // q (Score)
+    pub(crate) score: Option<Scalar>,
+    //
+    // Private Inputs
+    //
+    // v
+    pub(crate) bid_value: Scalar,
+    // r
+    pub(crate) bid_randomness: Scalar,
+    // k
+    pub(crate) secret_k: Scalar,
+    // R = r * G
+    pub(crate) pk: G1Affine,
+}

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -29,11 +29,11 @@ pub struct Bid {
     // Private Inputs
     //
     // v
-    pub(crate) value: Scalar,
+    pub(crate) value: JubJubScalar,
     // r
-    pub(crate) randomness: Scalar,
+    pub(crate) randomness: JubJubScalar,
     // k
-    pub(crate) secret_k: JubJubScalar,
+    pub(crate) secret_k: Scalar,
     // R = r * G
     pub(crate) pk: AffinePoint,
 }
@@ -47,9 +47,9 @@ impl Default for Bid {
             latest_consensus_step: Scalar::zero(),
             prover_id: None,
             score: None,
-            value: Scalar::zero(),
-            randomness: Scalar::zero(),
-            secret_k: JubJubScalar::zero(),
+            value: JubJubScalar::zero(),
+            randomness: JubJubScalar::zero(),
+            secret_k: Scalar::zero(),
             pk: AffinePoint::default(),
         }
     }
@@ -61,9 +61,9 @@ impl Bid {
         consensus_round_seed: Scalar,
         latest_consensus_round: Scalar,
         latest_consensus_step: Scalar,
-        bid_value: Scalar,
-        bid_randomness: Scalar,
-        secret_k: JubJubScalar,
+        bid_value: JubJubScalar,
+        bid_randomness: JubJubScalar,
+        secret_k: Scalar,
         pk: AffinePoint,
     ) -> Self {
         // Initialize the Bid with the fields we were provided.

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -9,135 +9,49 @@ use dusk_plonk::constraint_system::{StandardComposer, Variable};
 use failure::Error;
 use poseidon252::{sponge::sponge::*, StorageScalar};
 
-const BYTE_PADDING_LEN: usize = 28;
-
-/// Encodes a `Bid` in a `StorageScalar` form by applying the correct padding
-/// and encoding methods stated in https://hackmd.io/@7dpNYqjKQGeYC7wMlPxHtQ/BkfS78Y9L
+/// Encodes a `Bid` in a `StorageScalar` form by applying the correct encoding methods
 /// and collapsing it into a `StorageScalar` which can be then stored inside of a
 /// `kelvin` tree data structure.
 pub(crate) fn tree_leaf_encoding(bid: &Bid) -> Result<StorageScalar, Error> {
-    // Generate an empty vector of bytes which will store the padded & encoded
-    // byte-representation of all of the `Bid` elements.
-    let mut byte_container = Vec::with_capacity(28 * 9);
+    // Generate an empty vector of `Scalar` which will store the representation
+    // of all of the `Bid` elements that a.
+    let mut words_deposit = Vec::new();
     // Note that the merkle_tree_root is not used since we can't pre-compute
     // it. Therefore, any field that relies on it to be computed isn't neither
     // used to obtain this encoded form.
-    pad_and_accumulate(&mut byte_container, &bid.consensus_round_seed.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.latest_consensus_round.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.latest_consensus_step.to_bytes());
+
+    // 1. Generate the type_fields Scalar Id:
+    // Type 1 will be BlsScalar
+    // Type 2 will be JubJubScalar
+    // Type 3 will be JubJubAffine
+    // Treated in Little Endian.
+    let type_fields = Scalar::from_bytes(b"11111122130000000000000000000000");
+
+    // 2. Encode each word.
+    // Scalar and any other type that can be embedded in, will also be treated as one.
+    words_deposit.push(bid.consensus_round_seed);
+    words_deposit.push(bid.latest_consensus_round);
+    words_deposit.push(bid.latest_consensus_step);
     if bid.prover_id == None {
         return Err(BidError::MissingBidFields.into());
     };
-    pad_and_accumulate(&mut byte_container, &bid.prover_id.unwrap().to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.value.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.randomness.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.secret_k.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.pk.to_bytes());
-    // Now that we have all of our values encoded inside the container,
-    // collapse it and return the result.
-    collapse_accumulator(&byte_container)
-}
-
-/// Encodes a `Bid` in a `StorageScalar` form by applying the correct padding
-/// and encoding methods stated in https://hackmd.io/@7dpNYqjKQGeYC7wMlPxHtQ/BkfS78Y9L
-/// and collapsing it into a `StorageScalar` which can be then stored inside of a
-/// `kelvin` tree data structure.
-///
-/// It also prints into the Constraint System, the sponge hash that produces the `StorageScalar`.
-/// On this way, we prove that the leaf value was correctly encoded.
-pub(crate) fn tree_leaf_encoding_gadget(
-    composer: &mut StandardComposer,
-    bid: &Bid,
-) -> Result<Variable, Error> {
-    // Generate an empty vector of bytes which will store the padded & encoded
-    // byte-representation of all of the `Bid` elements.
-    let mut byte_container = Vec::with_capacity(28 * 9);
-    // Note that the merkle_tree_root is not used since we can't pre-compute
-    // it. Therefore, any field that relies on it to be computed isn't neither
-    // used to obtain this encoded form.
-    pad_and_accumulate(&mut byte_container, &bid.consensus_round_seed.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.latest_consensus_round.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.latest_consensus_step.to_bytes());
-    if bid.prover_id == None {
+    words_deposit.push(bid.prover_id.unwrap());
+    if bid.score == None {
         return Err(BidError::MissingBidFields.into());
-    };
-    pad_and_accumulate(&mut byte_container, &bid.prover_id.unwrap().to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.value.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.randomness.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.secret_k.to_bytes());
-    pad_and_accumulate(&mut byte_container, &bid.pk.to_bytes());
-    // Now that we have all of our values encoded inside the container,
-    // collapse it and return the result.
-    collapse_accumulator_gadget(composer, &byte_container)
-}
-
-/// Applies the correct padding to whatever data structure that can be represented
-/// as bytes.
-fn pad_and_accumulate(byte_storage: &mut Vec<u8>, elem_as_bytes: &[u8]) {
-    // Push the bytes of the element into the byte_storage.
-    byte_storage.extend(elem_as_bytes.iter());
-    // Pad the element with `0x7`.
-    byte_storage.push(7u8);
-    // Pad with 0's until we reach a multiple of BYTE_PADDING_LEN as the total len of the byte storage.
-    if byte_storage.len() % BYTE_PADDING_LEN != 0 {
-        // Compute how much 0's we need to add as padding. And then, padd with 0's.
-        byte_storage
-            .extend(vec![0u8; BYTE_PADDING_LEN - byte_storage.len() % BYTE_PADDING_LEN].iter());
     }
-}
+    words_deposit.push(bid.score.unwrap());
+    // Wrap up JubJubScalar bytes into BlsScalar bytes for value and randomness terms
+    words_deposit.push(Scalar::from_bytes(&bid.value.to_bytes()).unwrap());
+    words_deposit.push(Scalar::from_bytes(&bid.randomness.to_bytes()).unwrap());
+    words_deposit.push(bid.secret_k);
+    // Push both JubJubAffine coordinates as a Scalar.
+    words_deposit.push(Scalar::from_bytes(&bid.pk.get_x().to_bytes()).unwrap());
+    words_deposit.push(Scalar::from_bytes(&bid.pk.get_y().to_bytes()).unwrap());
 
-/// Collapses a collection of previously-padded bytes into a single `StorageScalar`
-/// using the Poseidon Sponge Hash function.
-fn collapse_accumulator(byte_storage: &[u8]) -> Result<StorageScalar, Error> {
-    // If the len is not multiple of BYTE_PADDING_LEN, return an error.
-    if byte_storage.len() % BYTE_PADDING_LEN != 0 {
-        return Err(BidError::WrongPadding.into());
-    };
-    // Generate a `Scalar` Vec where each `Scalar` is built from a chunk of 28 bytes
-    // of the original `byte_storage`.
-    let mut scalar_words = vec![];
-    for chunk in byte_storage.chunks(BYTE_PADDING_LEN) {
-        // Generate a 32-byte empty chunk
-        let mut inserted_chunk = [0u8; 32];
-        // Pad the 4-last bytes with zeroes since `Scalar::from_bytes()` expects
-        // a `&[u8; 32]`.
-        inserted_chunk[0..28].copy_from_slice(chunk);
-        // Push the Scalar word to the `scalar_words` vec.
-        scalar_words.push(Scalar::from_bytes(&inserted_chunk).unwrap());
-    }
-    // Apply the sponge hash function to collapse all chunks into a single
-    // `Scalar`.
-    Ok(StorageScalar(sponge_hash(&scalar_words)))
-}
-
-/// Collapses a collection of previously-padded bytes into a single `StorageScalar`
-/// using the Poseidon Sponge Hash function.
-///
-/// This prints into the CS the sponge hash operation in order to prove that the
-/// obtained leaf encoding was correctly obtained.
-fn collapse_accumulator_gadget(
-    composer: &mut StandardComposer,
-    byte_storage: &[u8],
-) -> Result<Variable, Error> {
-    // If the len is not multiple of BYTE_PADDING_LEN, return an error.
-    if byte_storage.len() % BYTE_PADDING_LEN != 0 {
-        return Err(BidError::WrongPadding.into());
-    };
-    // Generate a `Scalar` Vec where each `Scalar` is built from a chunk of 28 bytes
-    // of the original `byte_storage`.
-    let mut scalar_words = vec![];
-    for chunk in byte_storage.chunks(BYTE_PADDING_LEN) {
-        // Generate a 32-byte empty chunk
-        let mut inserted_chunk = [0u8; 32];
-        // Pad the 4-last bytes with zeroes since `Scalar::from_bytes()` expects
-        // a `&[u8; 32]`.
-        inserted_chunk[0..28].copy_from_slice(chunk);
-        // Push the Scalar word to the `scalar_words` vec.
-        scalar_words.push(composer.add_input(Scalar::from_bytes(&inserted_chunk).unwrap()));
-    }
-    // Apply the sponge hash function to collapse all chunks into a single
-    // `Scalar`.
-    Ok(sponge_hash_gadget(composer, &scalar_words))
+    // Once all of the words are translated as `Scalar` and stored correctly,
+    // apply the Poseidon sponge hash function to obtain the encoded form of the
+    // `Bid`.
+    Ok(StorageScalar(sponge_hash(&words_deposit)))
 }
 
 #[cfg(test)]
@@ -150,94 +64,9 @@ mod tests {
     use jubjub::{AffinePoint, Scalar as JubJubScalar};
     use merlin::Transcript;
 
-    #[test]
-    fn test_word_padding() {
-        let scalar = Scalar::from(10u64);
-        let bytes = [3u8, 0xa, 0xd];
-        // Generate a container.
-        let mut byte_container = vec![];
-        pad_and_accumulate(&mut byte_container, &scalar.to_bytes());
-        pad_and_accumulate(&mut byte_container, &bytes);
-        let collapsed_accum_obtained = collapse_accumulator(&byte_container).unwrap();
-
-        // Define the expected collapsed accumulator. Len has to be multiple of 28 and in
-        // this case, with a len of 84 will be enough.
-        let collapsed_accum_expected = [
-            10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 10,
-            13, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        ];
-        let chunks: Vec<Scalar> = collapsed_accum_expected
-            .chunks(28)
-            .map(|chunk| {
-                let mut bytes = [0u8; 32];
-                bytes[0..28].copy_from_slice(chunk);
-                Scalar::from_bytes(&bytes).unwrap()
-            })
-            .collect();
-
-        let final_expected_scalar = sponge_hash(&chunks);
-
-        assert_eq!(final_expected_scalar, collapsed_accum_obtained.0)
-    }
-
-    #[test]
-    fn test_encoding_gadget() {
-        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
-
-        let mut composer = StandardComposer::new();
-        let mut transcript = Transcript::new(b"Test");
-
-        // Generate a `Bid` with computed `score`.
-        let bid = Bid::new(
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            // XXX: Set to random as soon as https://github.com/dusk-network/jubjub/issues/4
-            // gets closed.
-            JubJubScalar::one(),
-            AffinePoint::identity(),
-        );
-
-        let encoded_leaf_val = tree_leaf_encoding(&bid).unwrap();
-        let encoded_leaf_obtained_var = tree_leaf_encoding_gadget(&mut composer, &bid).unwrap();
-
-        // Check that the results are the same by adding a constraint.
-        composer.constrain_to_constant(
-            encoded_leaf_obtained_var,
-            encoded_leaf_val.0,
-            Scalar::zero(),
-        );
-
-        // Prove and Verify to check that indeed, the score is correct.
-        composer.add_dummy_constraints();
-
-        let prep_circ =
-            composer.preprocess(&ck, &mut transcript, &EvaluationDomain::new(8709).unwrap());
-
-        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
-        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &vec![Scalar::zero()]));
-    }
-
     #[ignore]
     #[test]
-    fn test_bid_encoding() {
-        let bid = Bid::new(
-            Scalar::one(),
-            Scalar::one(),
-            Scalar::one(),
-            Scalar::one(),
-            Scalar::one(),
-            Scalar::one(),
-            // Set to one so the inverse does not fail.
-            JubJubScalar::one(),
-            AffinePoint::identity(),
-        );
-        // We need test vectors for this.
-        // See: https://github.com/dusk-network/dusk-blindbid/issues/8
+    fn test_word_padding() {
+        // This cannot be tested until we don't get propper test vectors from the research side.
     }
 }

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -1,0 +1,78 @@
+//! Encoding module for Bid structure.
+//!
+//! See: https://hackmd.io/@7dpNYqjKQGeYC7wMlPxHtQ/BkfS78Y9L
+
+use super::errors::BidError;
+use super::Bid;
+use dusk_bls12_381::Scalar;
+use failure::Error;
+use poseidon252::{sponge::sponge::*, StorageScalar};
+
+const BYTE_PADDING_LEN: usize = 28;
+
+/// Encodes a `Bid` in a `StorageScalar` form by applying the correct padding
+/// and encoding methods stated in https://hackmd.io/@7dpNYqjKQGeYC7wMlPxHtQ/BkfS78Y9L
+/// and collapsing it into a `StorageScalar` which can be then stored inside of a
+/// `kelvin` tree data structure.
+pub(crate) fn tree_leaf_encoding(bid: &Bid) -> Result<StorageScalar, Error> {
+    // Generate an empty vector of bytes which will store the padded & encoded
+    // byte-representation of all of the `Bid` elements.
+    let mut byte_container = Vec::with_capacity(28 * 9);
+    // Note that the merkle_tree_root is not used since we can't pre-compute
+    // it. Therefore, any field that relies on it to be computed isn't neither
+    // used to obtain this encoded form.
+    pad_and_accumulate(&mut byte_container, &bid.consensus_round_seed.to_bytes());
+    pad_and_accumulate(&mut byte_container, &bid.latest_consensus_round.to_bytes());
+    pad_and_accumulate(&mut byte_container, &bid.latest_consensus_step.to_bytes());
+    if bid.prover_id == None {
+        return Err(BidError::MissingBidFields.into());
+    };
+    pad_and_accumulate(&mut byte_container, &bid.prover_id.unwrap().to_bytes());
+    pad_and_accumulate(&mut byte_container, &bid.value.to_bytes());
+    pad_and_accumulate(&mut byte_container, &bid.randomness.to_bytes());
+    pad_and_accumulate(&mut byte_container, &bid.secret_k.to_bytes());
+    pad_and_accumulate(&mut byte_container, &bid.pk.to_bytes());
+
+    // Now that we have all of our values encoded inside the container,
+    // collapse it and return the result.
+    collapse_accumulator(&byte_container)
+}
+
+/// Applies the correct padding to whatever data structure that can be represented
+/// as bytes.
+fn pad_and_accumulate(byte_storage: &mut Vec<u8>, elem_as_bytes: &[u8]) {
+    // Push the bytes of the element into the byte_storage.
+    byte_storage.extend(elem_as_bytes.iter());
+    // Pad the element with `0x7`.
+    byte_storage.push(7u8);
+    // Pad with 0's until we reach a multiple of BYTE_PADDING_LEN as the total len of the byte storage.
+    if byte_storage.len() % BYTE_PADDING_LEN != 0 {
+        // Compute how much 0's we need to add as padding. And then, padd with 0's.
+        byte_storage
+            .extend(vec![0u8; BYTE_PADDING_LEN - byte_storage.len() % BYTE_PADDING_LEN].iter());
+    }
+}
+
+/// Collapses a collection of previously-padded bytes into a single `StorageScalar`
+/// using the Poseidon Sponge Hash function.
+fn collapse_accumulator(byte_storage: &[u8]) -> Result<StorageScalar, Error> {
+    // If the len is not multiple of BYTE_PADDING_LEN, return an error.
+    if byte_storage.len() % BYTE_PADDING_LEN != 0 {
+        return Err(BidError::WrongPadding.into());
+    };
+    // Generate a `Scalar` Vec where each `Scalar` is built from a chunk of 28 bytes
+    // of the original `byte_storage`.
+    let mut scalar_words = vec![];
+    for chunk in byte_storage.chunks(BYTE_PADDING_LEN) {
+        // Generate a 32-byte empty chunk
+        let mut inserted_chunk = [0u8; 32];
+        // Pad the 4-first bits as zero since `Scalar::from_bytes()` expects
+        // a `&[u8; 32]`.
+        inserted_chunk[4..32].copy_from_slice(chunk);
+        // Push the Scalar word to the `scalar_words` vec.
+        scalar_words.push(Scalar::from_bytes(&inserted_chunk).unwrap());
+    }
+    // Apply the sponge hash function to collapse all chunks into a single
+    // `Scalar`.
+    Ok(StorageScalar(sponge_hash(&scalar_words)))
+}

--- a/src/bid/errors.rs
+++ b/src/bid/errors.rs
@@ -1,0 +1,17 @@
+//! Errors related to the Bid
+
+use failure::Error;
+use failure::Fail;
+
+/// Definition of the erros that Bid operations might have.
+#[derive(Fail, Debug)]
+pub enum BidError {
+    /// Error for the cases when we encode a `Bid` that does not have
+    /// computed the `prover_id` or the `score`.
+    #[fail(display = "bid doesn't have computed all of it's fields")]
+    MissingBidFields,
+    /// Error triggers when we try to collapse a byte-accumulator that
+    /// is not correctly padded.
+    #[fail(display = "byte_accumulator length is not correct")]
+    WrongPadding,
+}

--- a/src/bid/errors.rs
+++ b/src/bid/errors.rs
@@ -1,6 +1,5 @@
 //! Errors related to the Bid
 
-use failure::Error;
 use failure::Fail;
 
 /// Definition of the erros that Bid operations might have.

--- a/src/bid/mod.rs
+++ b/src/bid/mod.rs
@@ -1,2 +1,4 @@
 pub(crate) mod bid;
 pub use bid::Bid;
+pub(crate) mod encoding;
+pub(crate) mod errors;

--- a/src/bid/mod.rs
+++ b/src/bid/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod bid;
+pub use bid::Bid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+//! BlindBid impl
+
+pub mod bid;
+pub mod proof;
+pub mod score_gen;

--- a/src/proof/blindbid_proof.rs
+++ b/src/proof/blindbid_proof.rs
@@ -1,0 +1,9 @@
+//! BlindBidProof module.
+//!
+
+use crate::bid::Bid;
+use dusk_plonk::constraint_system::StandardComposer;
+
+pub fn blind_bid_proof(composer: &mut StandardComposer, bid: &Bid) {
+    unimplemented!()
+}

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -1,0 +1,1 @@
+pub mod blindbid_proof;

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -1,0 +1,1 @@
+pub mod score;

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -102,6 +102,7 @@ mod tests {
     use dusk_plonk::fft::EvaluationDomain;
     use merlin::Transcript;
 
+    #[ignore]
     #[test]
     fn gadget_score_is_scalar_score() {
         // Generate Composer & Public Parameters

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -1,0 +1,98 @@
+//! Score generation
+
+use crate::bid::Bid;
+use dusk_bls12_381::Scalar;
+use dusk_plonk::constraint_system::{StandardComposer, Variable};
+use poseidon252::sponge::*;
+
+pub fn compute_score(bid: &Bid) -> Scalar {
+    // Compute `y` where `y = H(secret_k, Merkle_root, consensus_round_seed, latest_consensus_round, latest_consensus_step)`.
+    let y = sponge::sponge_hash(&[
+        bid.secret_k,
+        bid.bid_tree_root,
+        bid.consensus_round_seed,
+        bid.latest_consensus_round,
+        bid.latest_consensus_step,
+    ]);
+    // Compute y' and 1/y'.
+    let (_, inv_y_prime) = compute_y_primes(y);
+    // Return the score `q = v*2^128 / y'`.
+    bid.bid_value * Scalar::from(2u64).pow(&[128, 0, 0, 0]) * inv_y_prime
+}
+
+pub fn compute_score_gadget(
+    composer: &mut StandardComposer,
+    bid: &Bid,
+    bid_value: Variable,
+    secret_k: Variable,
+    bid_tree_root: Variable,
+    consensus_round_seed: Variable,
+    latest_consensus_round: Variable,
+    latest_consensus_step: Variable,
+) -> Variable {
+    // Compute `y` where `y = H(secret_k, Merkle_root, consensus_round_seed, latest_consensus_round, latest_consensus_step)`.
+    // This is done in ZK using the sponge hash gadget.
+    let y = sponge::sponge_hash_gadget(
+        composer,
+        &[
+            secret_k,
+            bid_tree_root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        ],
+    );
+    // We also need to compute the sponge hash with the scalars since we need to prove the correctness of the inverse
+    // of y'.
+    let scalar_y = sponge::sponge_hash(&[
+        bid.secret_k,
+        bid.bid_tree_root,
+        bid.consensus_round_seed,
+        bid.latest_consensus_round,
+        bid.latest_consensus_step,
+    ]);
+    // Compute 1/y' where `y' = y & 2^129 -1`. This needs to be done for `Scalar` and `Variable` backends
+    // to then assert that the inverse is correct.
+    // Compute y' and 1/y'.
+    let (_, inv_y_prime_scalar) = compute_y_primes(scalar_y);
+
+    // Compute y' as a Variable.
+    let y_prime_var = {
+        let truncate_val =
+            composer.add_input(Scalar::from(2u64).pow(&[129, 0, 0, 0]) - Scalar::one());
+        composer.logic_and_gate(y, truncate_val, 256)
+    };
+
+    // Generate a Variable for 1/y'.
+    let supposed_inv_y_prime = composer.add_input(inv_y_prime_scalar);
+    // Check that 1/y' is indeed the inverse of y'.
+    // To do that, we multiply the real 1/y' and the computed y' and subtract one.
+    // This is indeed the constraint that verifies the integrity of the inverse.
+    //
+    // We don't need the input since it should be 0. If it is not, the verification process
+    // will fail.
+    composer.mul(
+        Scalar::one(),
+        y_prime_var,
+        supposed_inv_y_prime,
+        -Scalar::one(),
+        Scalar::zero(),
+    );
+    // Return the score `q = v*2^128 / y'`.
+    composer.mul(
+        Scalar::from(2u64).pow(&[128, 0, 0, 0]),
+        bid_value,
+        supposed_inv_y_prime,
+        Scalar::zero(),
+        Scalar::zero(),
+    )
+}
+
+// Given the y parameter, return the y' and it's inverse value.
+fn compute_y_primes(y: Scalar) -> (Scalar, Scalar) {
+    // Compute y'
+    let y_prime = y & (Scalar::from(2u64).pow(&[129, 0, 0, 0]) - Scalar::one());
+    // Compute 1/y' where `y' = y & 2^129 -1`
+    let inv_y_prime = y.invert().unwrap();
+    (y_prime, inv_y_prime)
+}

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -17,7 +17,7 @@ pub fn compute_score(bid: &Bid) -> Scalar {
     // Compute y' and 1/y'.
     let (_, inv_y_prime) = compute_y_primes(y);
     // Return the score `q = v*2^128 / y'`.
-    bid.bid_value * Scalar::from(2u64).pow(&[128, 0, 0, 0]) * inv_y_prime
+    bid.value * Scalar::from(2u64).pow(&[128, 0, 0, 0]) * inv_y_prime
 }
 
 pub fn compute_score_gadget(

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -7,18 +7,7 @@ use jubjub::{AffinePoint, Scalar as JubJubScalar};
 use poseidon252::sponge::*;
 
 pub fn compute_score(bid: &Bid) -> Scalar {
-    // Compute `y` where `y = H(secret_k, Merkle_root, consensus_round_seed, latest_consensus_round, latest_consensus_step)`.
-    let y = sponge::sponge_hash(&[
-        Scalar::from_bytes(&bid.secret_k.to_bytes()).unwrap(),
-        bid.bid_tree_root,
-        bid.consensus_round_seed,
-        bid.latest_consensus_round,
-        bid.latest_consensus_step,
-    ]);
-    // Compute y' and 1/y'.
-    let (_, inv_y_prime) = compute_y_primes(y);
-    // Return the score `q = v*2^128 / y'`.
-    bid.value * Scalar::from(2u64).pow(&[128, 0, 0, 0]) * inv_y_prime
+    unimplemented!()
 }
 
 /// Computes the score of the bid printing in the ConstraintSystem the proof of the correct
@@ -128,16 +117,17 @@ mod tests {
             Scalar::random(&mut rand::thread_rng()),
             Scalar::random(&mut rand::thread_rng()),
             Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
+            JubJubScalar::one(),
+            JubJubScalar::one(),
             // XXX: Set to random as soon as https://github.com/dusk-network/jubjub/issues/4
             // gets closed.
-            JubJubScalar::one(),
+            Scalar::random(&mut rand::thread_rng()),
             AffinePoint::identity(),
         );
 
         // Add as `Variable` to the composer the required values by the compute_score_gadget fn
-        let bid_val_variable = composer.add_input(bid.value);
+        let bid_val_variable =
+            composer.add_input(Scalar::from_bytes(&bid.value.to_bytes()).unwrap());
         // We wrap up the JubJubScalar as a BlsScalar which will always fit.
         // That means that the unwrap is safe.
         let secret_k_variable =

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -132,7 +132,7 @@ mod tests {
             Scalar::random(&mut rand::thread_rng()),
             // XXX: Set to random as soon as https://github.com/dusk-network/jubjub/issues/4
             // gets closed.
-            JubJubScalar::zero(),
+            JubJubScalar::one(),
             AffinePoint::identity(),
         );
 
@@ -159,7 +159,6 @@ mod tests {
         );
 
         composer.constrain_to_constant(computed_score, bid.score.unwrap(), Scalar::zero());
-        print!("{:?}", composer.circuit_size());
         // Prove and Verify to check that indeed, the score is correct.
         composer.add_dummy_constraints();
 


### PR DESCRIPTION
Implements the needed encoding functionalities needed to be able to compress `Bid`s into `Scalar` so we can store them and hash them with Poseidon and `kelvin` trees.

Closes #5 