### PR TITLE
Score generation refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-dusk-plonk = {version = "0.1.0", features = ["trace-print"]}
+dusk-plonk = {version = "0.1.0", features = ["trace-print", "trace"]}
 dusk-bls12_381 = "0.1.0"
 hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-dusk-plonk = "0.1.0"
+dusk-plonk = {version = "0.1.0", features = ["trace-print"]}
 dusk-bls12_381 = "0.1.0"
 hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "me
 failure = "0.1.7"
 kelvin = "0.13.0"
 jubjub = {git = "https://github.com/dusk-network/jubjub", branch = "master"}
+num-bigint = "0.2.6"
+num-traits = "0.2.11"
 
 [dev-dependencies]
 merlin = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-dusk-plonk = {version = "0.1.0", features = ["trace-print", "trace"]}
+dusk-plonk = {version = "0.1.0"}
 dusk-bls12_381 = "0.1.0"
 hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -1,8 +1,9 @@
 //! Bid data structure
 //!
 
-use crate::score_gen::score::compute_score;
+use crate::score_gen::{compute_score, Score};
 use dusk_bls12_381::Scalar;
+use failure::Error;
 use jubjub::{AffinePoint, Scalar as JubJubScalar};
 use poseidon252::sponge::sponge::sponge_hash;
 
@@ -24,7 +25,7 @@ pub struct Bid {
     // i (One time identity of the prover)
     pub(crate) prover_id: Option<Scalar>,
     // q (Score of the bid)
-    pub(crate) score: Option<Scalar>,
+    pub(crate) score: Option<Score>,
     //
     // Private Inputs
     //
@@ -48,7 +49,7 @@ impl Bid {
         bid_randomness: JubJubScalar,
         secret_k: Scalar,
         pk: AffinePoint,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         // Initialize the Bid with the fields we were provided.
         let mut bid = Bid {
             bid_tree_root,
@@ -65,9 +66,9 @@ impl Bid {
         // Compute and add to the Bid the `prover_id`.
         bid.generate_prover_id();
         // Compute score and append it to the Bid.
-        bid.score = Some(compute_score(&bid));
+        bid.score = Some(compute_score(&bid)?);
 
-        bid
+        Ok(bid)
     }
 
     /// One-time prover-id is stated to be H(secret_k, sigma^s, k^t, k^s).

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -6,7 +6,7 @@ use dusk_bls12_381::Scalar;
 use jubjub::{AffinePoint, Scalar as JubJubScalar};
 use poseidon252::sponge::sponge::sponge_hash;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Bid {
     // Pub Inputs
     //
@@ -36,23 +36,6 @@ pub struct Bid {
     pub(crate) secret_k: Scalar,
     // R = r * G
     pub(crate) pk: AffinePoint,
-}
-
-impl Default for Bid {
-    fn default() -> Self {
-        Bid {
-            bid_tree_root: Scalar::zero(),
-            consensus_round_seed: Scalar::zero(),
-            latest_consensus_round: Scalar::zero(),
-            latest_consensus_step: Scalar::zero(),
-            prover_id: None,
-            score: None,
-            value: JubJubScalar::zero(),
-            randomness: JubJubScalar::zero(),
-            secret_k: Scalar::zero(),
-            pk: AffinePoint::default(),
-        }
-    }
 }
 
 impl Bid {

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -3,6 +3,11 @@
 
 use crate::score_gen::{compute_score, Score};
 use dusk_bls12_381::Scalar;
+use dusk_plonk::{
+    commitment_scheme::kzg10::{ProverKey, PublicParameters},
+    constraint_system::StandardComposer,
+    proof_system::Proof,
+};
 use failure::Error;
 use jubjub::{AffinePoint, Scalar as JubJubScalar};
 use poseidon252::sponge::sponge::sponge_hash;
@@ -82,5 +87,13 @@ impl Bid {
             self.latest_consensus_round,
             self.latest_consensus_step,
         ]));
+    }
+
+    pub fn prove_score_generation(&self, composer: &mut StandardComposer) -> Result<Proof, Error> {
+        use crate::score_gen::score::prove_correct_score_gadget;
+
+        prove_correct_score_gadget(composer, self)?;
+        // XXX: Return the proof with a pre-computed PreprocessedCircuit and ProverKey
+        unimplemented!()
     }
 }

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -39,7 +39,7 @@ pub(crate) fn tree_leaf_encoding(bid: &Bid) -> Result<StorageScalar, Error> {
     if bid.score == None {
         return Err(BidError::MissingBidFields.into());
     }
-    words_deposit.push(bid.score.unwrap());
+    words_deposit.push(bid.score.unwrap().score);
     // Wrap up JubJubScalar bytes into BlsScalar bytes for value and randomness terms
     words_deposit.push(Scalar::from_bytes(&bid.value.to_bytes()).unwrap());
     words_deposit.push(Scalar::from_bytes(&bid.randomness.to_bytes()).unwrap());

--- a/src/score_gen/errors.rs
+++ b/src/score_gen/errors.rs
@@ -1,0 +1,12 @@
+//! Errors related to the Score Generation
+
+use failure::Fail;
+
+/// Definition of the erros that Bid operations might have.
+#[derive(Fail, Debug)]
+pub enum ScoreError {
+    /// Error for the cases when we the score results are too large to
+    /// fit inside a `Scalar`.
+    #[fail(display = "score results do not fit inside of Scalar")]
+    InvalidScoreFieldsLen,
+}

--- a/src/score_gen/errors.rs
+++ b/src/score_gen/errors.rs
@@ -9,4 +9,7 @@ pub enum ScoreError {
     /// fit inside a `Scalar`.
     #[fail(display = "score results do not fit inside of Scalar")]
     InvalidScoreFieldsLen,
+    /// Error for computations of inverses that do not exists (non-Qr's)
+    #[fail(display = "Inverse of the Scalar does not exist")]
+    NonExistingInverse,
 }

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod errors;
 pub mod score;

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -1,2 +1,4 @@
 pub(crate) mod errors;
 pub mod score;
+pub(crate) use score::compute_score;
+pub use score::Score;

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -12,13 +12,21 @@ use poseidon252::sponge::*;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct Score {
     pub(crate) score: Scalar,
+    pub(crate) y: Scalar,
+    pub(crate) y_prime: Scalar,
     pub(crate) r1: Scalar,
     pub(crate) r2: Scalar,
 }
 
 impl Score {
-    pub(crate) fn new(score: Scalar, r1: Scalar, r2: Scalar) -> Self {
-        Score { score, r1, r2 }
+    pub(crate) fn new(score: Scalar, y: Scalar, y_prime: Scalar, r1: Scalar, r2: Scalar) -> Self {
+        Score {
+            score,
+            y,
+            y_prime,
+            r1,
+            r2,
+        }
     }
 }
 
@@ -46,7 +54,7 @@ pub fn compute_score(bid: &Bid) -> Result<Score, Error> {
         // r2 is assigned to the remainder of the division.
         false => {
             let num = bid_value * (BigUint::one() << 128);
-            (num.clone() / y_prime.clone(), num % y_prime)
+            (&num / &y_prime, &num % &y_prime)
         }
         // If y' == 0 -> f = bid_value * 2^128
         // Since there's not any division, r2 is assigned to 0 since
@@ -58,25 +66,16 @@ pub fn compute_score(bid: &Bid) -> Result<Score, Error> {
     // be correctly done.
     Ok(Score::new(
         biguint_to_scalar(f)?,
+        y,
+        biguint_to_scalar(y_prime)?,
         biguint_to_scalar(r1)?,
         biguint_to_scalar(r2)?,
     ))
 }
 
-/// Computes the score of the bid printing in the ConstraintSystem the proof of the correct
-/// obtention of the score.
-///
-/// Takes 3615 constraints.
-pub fn compute_score_gadget(
-    composer: &mut StandardComposer,
-    bid: &Bid,
-    bid_value: Variable,
-    secret_k: Variable,
-    bid_tree_root: Variable,
-    consensus_round_seed: Variable,
-    latest_consensus_round: Variable,
-    latest_consensus_step: Variable,
-) -> Variable {
+/// Proves that a `Score` is correctly generated.
+/// Prints the proving statements in the passed Constraint System.
+pub fn correct_score_gadget(composer: &mut StandardComposer, bid: &Bid) -> Variable {
     unimplemented!()
 }
 

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -84,7 +84,7 @@ pub fn compute_score_gadget(
 fn biguint_to_scalar(biguint: BigUint) -> Result<Scalar, Error> {
     let mut bytes = [0u8; 32];
     let biguint_bytes = biguint.to_bytes_le();
-    if biguint_bytes.len() >= 32 {
+    if biguint_bytes.len() > 32 {
         return Err(ScoreError::InvalidScoreFieldsLen.into());
     };
     bytes[0..biguint_bytes.len()].copy_from_slice(&biguint_bytes[..]);
@@ -100,4 +100,12 @@ mod tests {
     use dusk_plonk::constraint_system::{StandardComposer, Variable};
     use dusk_plonk::fft::EvaluationDomain;
     use merlin::Transcript;
+
+    #[test]
+    fn biguint_scalar_conversion() {
+        let rand_scalar = Scalar::random(&mut rand::thread_rng());
+        let big_uint = BigUint::from_bytes_le(&rand_scalar.to_bytes());
+
+        assert_eq!(biguint_to_scalar(big_uint).unwrap(), rand_scalar)
+    }
 }

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -1,6 +1,7 @@
 //! Score generation
 
 use super::errors::ScoreError;
+use crate::bid::errors::BidError;
 use crate::bid::Bid;
 use dusk_bls12_381::Scalar;
 use dusk_plonk::constraint_system::{StandardComposer, Variable};
@@ -75,8 +76,195 @@ pub fn compute_score(bid: &Bid) -> Result<Score, Error> {
 
 /// Proves that a `Score` is correctly generated.
 /// Prints the proving statements in the passed Constraint System.
-pub fn correct_score_gadget(composer: &mut StandardComposer, bid: &Bid) -> Variable {
-    unimplemented!()
+pub fn correct_score_gadget(composer: &mut StandardComposer, bid: &Bid) -> Result<(), Error> {
+    // Get score from the bid and err if it is not computed.
+    if bid.score.is_none() {
+        return Err(BidError::MissingBidFields.into());
+    };
+    let score = bid.score.unwrap();
+    // This unwrap is safe since the order of the JubJubScalar is shorter.
+    let bid_value = composer.add_input(Scalar::from_bytes(&bid.value.to_bytes()).unwrap());
+    // 1. Y = 2^128 * r1 + Y'
+    let r1 = composer.add_input(score.r1);
+    let r2 = composer.add_input(score.r2);
+    let y = composer.add_input(score.y);
+    let y_prime = composer.add_input(score.y_prime);
+    let score = composer.add_input(score.score);
+    let two_pow_128 = Scalar::from(2u64).pow(&[128, 0, 0, 0]);
+    composer.add_gate(
+        r1,
+        y_prime,
+        y,
+        two_pow_128,
+        Scalar::one(),
+        -Scalar::one(),
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+
+    // 2.(r1 < |Fr|/2^128 AND Y' +1  < 2^128 +1 ) OR (r1 = |Fr|/2^128 AND Y' < |Fr| mod 2^128).
+
+    // 2.1. First op will be a complex rangeproof between r1 and the range (Order of the Scalar Field / 2^128 (No modular division))
+    // The result should be 0 if the rangeproof holds.
+
+    // 2.2. Then we have a single Rangeproof between Y' being in the range [0-2^128]
+
+    // 2.3. Third, we have an equalty checking between r1 & the order of the Scalar field divided (no modular division)
+    // by 2^128.
+    // We simply subtract both values and if it's equal, we will get a 0.
+
+    // 2.4. Finally, A rangeproof for y' checking it's between [0, Order of the ScalarField mod 2^128]. We will apply the complex
+    // rangeproof too.
+    let minus_one_div_2_pow_128 = { unimplemented!() };
+    // It will be equal to 0 if the range proof holds.
+    let first_r1_range =
+        single_complex_range_proof(composer, bid.score.unwrap().r1, minus_one_div_2_pow_128);
+
+    // 3. r2 < Y' we need a 128-bit range_proof
+    let should_be_0 =
+        single_complex_range_proof(composer, bid.score.unwrap().r2, bid.score.unwrap().y_prime)?;
+    // Check that the result of the range_proof is indeed 0 to assert it passed.
+    composer.add_gate(
+        should_be_0,
+        composer.zero_var,
+        composer.zero_var,
+        Scalar::one(),
+        Scalar::one(),
+        Scalar::one(),
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+
+    // 4. f < 2^120
+    composer.range_gate(score, 120usize);
+    // 5. f*Y' + r2 -d*2^128 = 0
+    //
+    // f * Y'
+    let f_y_prime_prod = composer.mul(
+        Scalar::one(),
+        score,
+        y_prime,
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+    // f*Y' + r2
+    let left = composer.add(
+        (Scalar::one(), f_y_prime_prod),
+        (Scalar::one(), r2),
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+    // (f*Y' + r2) - d*2^128 = 0
+    composer.add_gate(
+        left,
+        bid_value,
+        composer.zero_var,
+        Scalar::one(),
+        -two_pow_128,
+        Scalar::zero(),
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+
+    Ok(())
+}
+
+// Builds a complex range-proof (not bounded to a pow_of_two) given a
+// composer, the max range and the witness.
+fn single_complex_range_proof(
+    composer: &mut StandardComposer,
+    witness: Scalar,
+    max_range: Scalar,
+) -> Result<Variable, Error> {
+    // The closest pow of two for Y' is 2^128
+    let two_pow_128 = Scalar::from(2u64).pow(&[128u64, 0, 0, 0]);
+    // Compute b' max range.
+    let b_prime = two_pow_128 - max_range;
+    // Obtain 128-bit representation of `witness + b'`.
+    let bits = scalar_to_bits(&(witness + b_prime));
+
+    let mut var_accumulator = composer.zero_var;
+    let mut accumulator = Scalar::zero();
+
+    bits.iter().enumerate().for_each(|(idx, bit)| {
+        let bit = composer.add_input(Scalar::from(*bit as u64));
+        // Apply boolean constraint to the bit.
+        composer.bool_gate(bit);
+        // Accumulate the bit multiplied by 2^(i-1) as a variable
+        var_accumulator = composer.add(
+            (Scalar::one(), var_accumulator),
+            (Scalar::from(2u64).pow(&[idx as u64, 0, 0, 0]), bit),
+            Scalar::zero(),
+            Scalar::zero(),
+        );
+        // Compute the same accumulator with scalars
+        accumulator = accumulator + (accumulator * Scalar::from(2u64).pow(&[idx as u64, 0, 0, 0]));
+    });
+    // Compute `Chi(x)` =  Sum(vi * 2^(i-1)) - (x + b').
+    let witness_plus_b_prime = composer.add_input(witness + b_prime);
+    // Note that the result will be equal to: `0 (if the reangeproof holds)
+    // or any other value if it doesn't.
+    let chi_x_var = composer.add(
+        (Scalar::one(), witness_plus_b_prime),
+        (-Scalar::one(), var_accumulator),
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+    println!("Circuit size at chi(x) comp: {:?}", chi_x_var);
+    // It is possible to replace a constraint $\chi(\mathbf{x})=0$ on variables $\mathbf{x}$
+    // with a set of constraints $\psi$ on  new variables $(u,y,z)$ such
+    // that $y=1$ if $\chi$ holds and $y=0$ otherwise.
+    // We introduce new variables $u,y,z$ that are computed as follows:
+    //
+    // u &= \chi(\mathbf{x});\\
+    // y &=\begin{cases}
+    // 0,& \text{if }u\neq 0;\\
+    // 1,& \text{if }u=0.
+    // \end{cases}\\
+    // z&=\begin{cases}
+    // 1/u,& \text{if }u\neq 0;\\
+    // 0,& \text{if }u=0.
+    // \end{cases}
+    let u = witness + b_prime - accumulator;
+    let y = if u == Scalar::zero() {
+        composer.add_input(Scalar::one())
+    } else {
+        composer.add_input(Scalar::zero())
+    };
+
+    if u.invert().is_none().into() {
+        return Err(BidError::MissingBidFields.into());
+    };
+    let z = composer.add_input(u.invert().unwrap());
+    // We can safely unwrap `u` now.
+    // Now we need to check the following to ensure we can provide a boolean
+    // result representing wether the rangeproof holds or not:
+    // `u = Chi(x)`.
+    // `u * z = 1 - y`.
+    // `y * u = 0`.
+    let one = composer.add_input(Scalar::one());
+    composer.add_gate(
+        one,
+        chi_x_var,
+        composer.zero_var,
+        u,
+        -Scalar::one(),
+        Scalar::zero(),
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+    let one_min_y = composer.add(
+        (Scalar::one(), one),
+        (-Scalar::one(), y),
+        Scalar::zero(),
+        Scalar::zero(),
+    );
+    let u_times_z = composer.mul(u, one, z, Scalar::zero(), Scalar::zero());
+    composer.assert_equal(one_min_y, u_times_z);
+    let y_times_u = composer.mul(u, one, y, Scalar::zero(), Scalar::zero());
+    composer.assert_equal(y_times_u, composer.zero_var);
+
+    Ok(y)
 }
 
 // Given the y parameter, return the y' and it's inverse value.
@@ -89,6 +277,17 @@ fn biguint_to_scalar(biguint: BigUint) -> Result<Scalar, Error> {
     bytes[0..biguint_bytes.len()].copy_from_slice(&biguint_bytes[..]);
     // Due to the previous conditions, we can unwrap here safely.
     Ok(Scalar::from_bytes(&bytes).unwrap())
+}
+
+fn scalar_to_bits(scalar: &Scalar) -> [u8; 256] {
+    let mut res = [0u8; 256];
+    let bytes = scalar.to_bytes();
+    for (byte, bits) in bytes.iter().zip(res.chunks_mut(8)) {
+        bits.iter_mut()
+            .enumerate()
+            .for_each(|(i, bit)| *bit = (byte >> i) & 1)
+    }
+    res
 }
 
 #[cfg(test)]
@@ -106,5 +305,35 @@ mod tests {
         let big_uint = BigUint::from_bytes_le(&rand_scalar.to_bytes());
 
         assert_eq!(biguint_to_scalar(big_uint).unwrap(), rand_scalar)
+    }
+
+    #[test]
+    fn complex_rangeproof() {
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut composer = StandardComposer::new();
+        let mut transcript = Transcript::new(b"TEST");
+
+        let res = single_complex_range_proof(
+            &mut composer,
+            Scalar::from(2u64).pow(&[127u64, 0, 0, 0]),
+            Scalar::from(2u64).pow(&[128u64, 0, 0, 0]) - Scalar::one(),
+        )
+        .unwrap();
+        println!("{:?} {:?}", res, composer.add_input(Scalar::one()));
+        composer.check_circuit_satisfied();
+        // Since we don't use all of the wires, we set some dummy constraints to avoid Committing
+        // to zero polynomials.
+        composer.add_dummy_constraints();
+
+        let prep_circ = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
+        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
     }
 }

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -435,12 +435,8 @@ mod tests {
         // Since we don't use all of the wires, we set some dummy constraints to avoid Committing
         // to zero polynomials.
         composer.add_dummy_constraints();
-
-        let prep_circ = composer.preprocess(
-            &ck,
-            &mut transcript,
-            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
-        );
+        let prep_circ =
+            composer.preprocess(&ck, &mut transcript, &EvaluationDomain::new(270).unwrap());
 
         let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
         // This should pass since the range_proof holds.
@@ -467,11 +463,8 @@ mod tests {
         // to zero polynomials.
         composer.add_dummy_constraints();
 
-        let prep_circ = composer.preprocess(
-            &ck,
-            &mut transcript,
-            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
-        );
+        let prep_circ =
+            composer.preprocess(&ck, &mut transcript, &EvaluationDomain::new(270).unwrap());
 
         let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
         // This should pass since the range_proof doesn't hold and we constrained the
@@ -504,12 +497,8 @@ mod tests {
         // to zero polynomials.
         composer.add_dummy_constraints();
 
-        let prep_circ = composer.preprocess(
-            &ck,
-            &mut transcript,
-            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
-        );
-
+        let prep_circ =
+            composer.preprocess(&ck, &mut transcript, &EvaluationDomain::new(1099).unwrap());
         let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
         assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
     }
@@ -544,11 +533,8 @@ mod tests {
         // to zero polynomials.
         composer.add_dummy_constraints();
 
-        let prep_circ = composer.preprocess(
-            &ck,
-            &mut transcript,
-            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
-        );
+        let prep_circ =
+            composer.preprocess(&ck, &mut transcript, &EvaluationDomain::new(1099).unwrap());
 
         let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
         assert!(!proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -31,7 +31,8 @@ impl Score {
     }
 }
 
-pub fn compute_score(bid: &Bid) -> Result<Score, Error> {
+/// Given a `Bid`, compute it's Score and return it.
+pub(crate) fn compute_score(bid: &Bid) -> Result<Score, Error> {
     // Compute `y` where `y = H(secret_k, Merkle_root, consensus_round_seed, latest_consensus_round, latest_consensus_step)`.
     let y = sponge::sponge_hash(&[
         bid.secret_k,
@@ -43,8 +44,8 @@ pub fn compute_score(bid: &Bid) -> Result<Score, Error> {
 
     // Truncate Y to left 128 bits and interpret the result as 128-bit integer.
     // Keep the right 128 bits as another integer (r1).
-    let y_prime = BigUint::from_bytes_le(&y.to_bytes()[16..32]);
-    let r1 = BigUint::from_bytes_le(&y.to_bytes()[0..16]);
+    let r1 = BigUint::from_bytes_le(&y.to_bytes()[16..32]);
+    let y_prime = BigUint::from_bytes_le(&y.to_bytes()[0..16]);
 
     // Get the bid value outside of the modular field and treat it as
     // an integer.
@@ -76,73 +77,146 @@ pub fn compute_score(bid: &Bid) -> Result<Score, Error> {
 
 /// Proves that a `Score` is correctly generated.
 /// Prints the proving statements in the passed Constraint System.
-pub fn correct_score_gadget(composer: &mut StandardComposer, bid: &Bid) -> Result<(), Error> {
+pub fn prove_correct_score_gadget(composer: &mut StandardComposer, bid: &Bid) -> Result<(), Error> {
     // Get score from the bid and err if it is not computed.
     if bid.score.is_none() {
         return Err(BidError::MissingBidFields.into());
     };
-    let score = bid.score.unwrap();
     // This unwrap is safe since the order of the JubJubScalar is shorter.
     let bid_value = composer.add_input(Scalar::from_bytes(&bid.value.to_bytes()).unwrap());
-    // 1. Y = 2^128 * r1 + Y'
+    // Safe to unwrap here.
+    let score = bid.score.unwrap();
     let r1 = composer.add_input(score.r1);
     let r2 = composer.add_input(score.r2);
     let y = composer.add_input(score.y);
     let y_prime = composer.add_input(score.y_prime);
-    let score = composer.add_input(score.score);
+    let score_var = composer.add_input(score.score);
     let two_pow_128 = Scalar::from(2u64).pow(&[128, 0, 0, 0]);
+    let two_pow_128_buint = BigUint::from_bytes_le(&two_pow_128.to_bytes());
+    // 1. Y = 2^128 * r1 + Y'
     composer.add_gate(
-        r1,
         y_prime,
+        r1,
         y,
-        two_pow_128,
         Scalar::one(),
+        two_pow_128,
         -Scalar::one(),
         Scalar::zero(),
         Scalar::zero(),
     );
-
-    // 2.(r1 < |Fr|/2^128 AND Y' +1  < 2^128 +1 ) OR (r1 = |Fr|/2^128 AND Y' < |Fr| mod 2^128).
-
+    // 2.(r1 < |Fr|/2^128 AND Y' < 2^128 +1 ) OR (r1 = |Fr|/2^128 AND Y' < |Fr| mod 2^128).
+    //
     // 2.1. First op will be a complex rangeproof between r1 and the range (Order of the Scalar Field / 2^128 (No modular division))
     // The result should be 0 if the rangeproof holds.
+    let minus_one_div_2_pow_128 = {
+        let min_one = BigUint::from_bytes_le(&(-Scalar::one()).to_bytes());
+        min_one / &two_pow_128_buint
+    };
+    let first_cond = single_complex_range_proof(
+        composer,
+        score.r1,
+        biguint_to_scalar(minus_one_div_2_pow_128.clone())?,
+    )?;
 
     // 2.2. Then we have a single Rangeproof between Y' being in the range [0-2^128]
-
+    let second_cond = single_complex_range_proof(composer, score.y_prime, two_pow_128)?;
     // 2.3. Third, we have an equalty checking between r1 & the order of the Scalar field divided (no modular division)
     // by 2^128.
     // We simply subtract both values and if it's equal, we will get a 0.
-
+    let third_cond = {
+        let one = composer.add_input(Scalar::one());
+        let zero_or_other = composer.add(
+            (Scalar::one(), r1),
+            (-biguint_to_scalar(minus_one_div_2_pow_128.clone())?, one),
+            Scalar::zero(),
+            Scalar::zero(),
+        );
+        let u = score.r1 - biguint_to_scalar(minus_one_div_2_pow_128)?;
+        // Conditionally assign `1` or `0` to `y`.
+        let y = if u == Scalar::zero() {
+            composer.add_input(Scalar::one())
+        } else {
+            composer.add_input(Scalar::zero())
+        };
+        // Conditionally assign `1/u` or `0` to z
+        let mut z = composer.zero_var;
+        if u != Scalar::zero() {
+            // If u != zero -> `z = 1/u`
+            // Otherways, `u = 0` as it was defined avobe.
+            // Check inverse existance, otherways, err.
+            if u.invert().is_none().into() {
+                return Err(ScoreError::NonExistingInverse.into());
+            };
+            // Safe to unwrap here.
+            z = composer.add_input(u.invert().unwrap());
+        }
+        // We can safely unwrap `u` now.
+        // Now we need to check the following to ensure we can provide a boolean
+        // result representing wether the rangeproof holds or not:
+        // `u = Chi(x)`.
+        // `u * z = 1 - y`.
+        // `y * u = 0`.
+        let one = composer.add_input(Scalar::one());
+        composer.add_gate(
+            one,
+            zero_or_other,
+            composer.zero_var,
+            u,
+            -Scalar::one(),
+            Scalar::zero(),
+            Scalar::zero(),
+            Scalar::zero(),
+        );
+        let one_min_y = composer.add(
+            (Scalar::one(), one),
+            (-Scalar::one(), y),
+            Scalar::zero(),
+            Scalar::zero(),
+        );
+        let u_times_z = composer.mul(u, one, z, Scalar::zero(), Scalar::zero());
+        composer.assert_equal(one_min_y, u_times_z);
+        let y_times_u = composer.mul(u, one, y, Scalar::zero(), Scalar::zero());
+        composer.assert_equal(y_times_u, composer.zero_var);
+        y
+    };
     // 2.4. Finally, A rangeproof for y' checking it's between [0, Order of the ScalarField mod 2^128]. We will apply the complex
     // rangeproof too.
-    let minus_one_div_2_pow_128 = { unimplemented!() };
-    // It will be equal to 0 if the range proof holds.
-    let first_r1_range =
-        single_complex_range_proof(composer, bid.score.unwrap().r1, minus_one_div_2_pow_128);
+    let minus_one_mod_2_pow_128 = {
+        let min_one = BigUint::from_bytes_le(&(-Scalar::one()).to_bytes());
+        min_one % &two_pow_128_buint
+    };
+    let fourth_cond = single_complex_range_proof(
+        composer,
+        score.y_prime,
+        biguint_to_scalar(minus_one_mod_2_pow_128)?,
+    )?;
+    // Apply the point 2 constraint.
+    //(r1 < |Fr|/2^128 AND Y' < 2^128 +1)
+    let left_assign = composer.logic_and_gate(first_cond, second_cond, 128);
+    // (r1 = |Fr|/2^128 AND Y' < |Fr| mod 2^128)
+    let right_assign = composer.logic_and_gate(third_cond, fourth_cond, 128);
+    // left_assign XOR right_assign = 1
+    // This is possible since condition 1. and 3. are mutually exclusive. That means
+    // that if one is true, the other part of the equation will be false (0).
+    // Therefore, we can apply an XOR and check that both sides of the equal are different
+    // since: Both can't be true, but both can be false, and this has to make the proof fail.
+    let should_be_true = composer.logic_xor_gate(left_assign, right_assign, 2);
+    composer.constrain_to_constant(should_be_true, Scalar::one(), Scalar::zero());
 
     // 3. r2 < Y' we need a 128-bit range_proof
-    let should_be_0 =
+    let should_be_1 =
         single_complex_range_proof(composer, bid.score.unwrap().r2, bid.score.unwrap().y_prime)?;
     // Check that the result of the range_proof is indeed 0 to assert it passed.
-    composer.add_gate(
-        should_be_0,
-        composer.zero_var,
-        composer.zero_var,
-        Scalar::one(),
-        Scalar::one(),
-        Scalar::one(),
-        Scalar::zero(),
-        Scalar::zero(),
-    );
+    composer.constrain_to_constant(should_be_1, Scalar::one(), Scalar::zero());
 
     // 4. f < 2^120
-    composer.range_gate(score, 120usize);
+    composer.range_gate(score_var, 120usize);
     // 5. f*Y' + r2 -d*2^128 = 0
     //
     // f * Y'
     let f_y_prime_prod = composer.mul(
         Scalar::one(),
-        score,
+        score_var,
         y_prime,
         Scalar::zero(),
         Scalar::zero(),
@@ -300,18 +374,11 @@ fn scalar_to_bits(scalar: &Scalar) -> [u8; 256] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dusk_bls12_381::G1Affine;
     use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
-    use dusk_plonk::constraint_system::{StandardComposer, Variable};
+    use dusk_plonk::constraint_system::StandardComposer;
     use dusk_plonk::fft::EvaluationDomain;
+    use jubjub::{AffinePoint, Fr as JubJubScalar};
     use merlin::Transcript;
-
-    #[test]
-    fn scalar_bits() {
-        let two_pow_128_min_one = Scalar::from(2u64).pow(&[128, 0, 0, 0]) - Scalar::one();
-        let bits = scalar_to_bits(&two_pow_128_min_one);
-        println!("{:?}", &bits[..]);
-    }
 
     #[test]
     fn biguint_scalar_conversion() {
@@ -382,5 +449,80 @@ mod tests {
         // This should pass since the range_proof doesn't hold and we constrained the
         // boolean result of it to be false.
         assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
+    }
+
+    #[test]
+    fn correct_score_gen_proof() {
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut composer = StandardComposer::new();
+        let mut transcript = Transcript::new(b"TEST");
+
+        // Generate a correct Bid
+        let bid = Bid::new(
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            JubJubScalar::from(99u64),
+            JubJubScalar::from(6546546u64),
+            Scalar::random(&mut rand::thread_rng()),
+            AffinePoint::identity(),
+        )
+        .unwrap();
+        prove_correct_score_gadget(&mut composer, &bid).unwrap();
+        // Since we don't use all of the wires, we set some dummy constraints to avoid Committing
+        // to zero polynomials.
+        composer.add_dummy_constraints();
+
+        let prep_circ = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
+        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
+    }
+
+    #[test]
+    fn incorrect_score_gen_proof() {
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut composer = StandardComposer::new();
+        let mut transcript = Transcript::new(b"TEST");
+
+        // Generate a correct Bid
+        let mut bid = Bid::new(
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            JubJubScalar::from(99u64),
+            JubJubScalar::from(6546546u64),
+            Scalar::random(&mut rand::thread_rng()),
+            AffinePoint::identity(),
+        )
+        .unwrap();
+        // Edit score fields
+        let mut score = bid.score.unwrap();
+        score.score = Scalar::from(5686536568u64);
+        score.r1 = Scalar::from(5898956968u64);
+        bid.score = Some(score);
+        prove_correct_score_gadget(&mut composer, &bid).unwrap();
+        // Since we don't use all of the wires, we set some dummy constraints to avoid Committing
+        // to zero polynomials.
+        composer.add_dummy_constraints();
+
+        let prep_circ = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
+        assert!(!proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
     }
 }


### PR DESCRIPTION
Now we have a way to prove the correctness of a generated Score
for a `Bid`.

- Added tests for correct and incorrect cases.
- Circuit_size atm = 1200 constraints aprox.

The Rust code can probably be a bit better. But I mainly focused on circuit correctness on this iteration.

Closes #6