### PR TITLE
Blind bid proof gadget implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 dusk-plonk = {version = "0.1.0"}
 dusk-bls12_381 = "0.1.0"
 hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.5.0"}
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", branch = "merkle_hashing"}
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.5.0"}
 failure = "0.1.7"
 kelvin = "0.13.0"
 jubjub = {git = "https://github.com/dusk-network/jubjub", branch = "master"}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 80
+wrap_comments = true

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -1,16 +1,13 @@
 //! Bid data structure
-//!
 
 use crate::score_gen::{compute_score, Score};
 use dusk_bls12_381::Scalar;
-use dusk_plonk::{
-    commitment_scheme::kzg10::{ProverKey, PublicParameters},
-    constraint_system::StandardComposer,
-    proof_system::Proof,
-};
+use dusk_plonk::{constraint_system::StandardComposer, proof_system::Proof};
 use failure::Error;
 use jubjub::{AffinePoint, Scalar as JubJubScalar};
 use poseidon252::sponge::sponge::sponge_hash;
+pub(crate) mod encoding;
+pub use encoding::StorageBid;
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Bid {
@@ -54,49 +51,13 @@ pub struct Bid {
 }
 
 impl Bid {
-    pub fn new(
-        bid_tree_root: Scalar,
-        consensus_round_seed: Scalar,
-        latest_consensus_round: Scalar,
-        latest_consensus_step: Scalar,
-        elegibility_ts: u32,
-        expiration_ts: u32,
-        blinder: JubJubScalar,
-        encrypted_blinder: JubJubScalar,
-        value: JubJubScalar,
-        encrypted_value: JubJubScalar,
-        randomness: AffinePoint,
-        secret_k: Scalar,
-        hashed_secret: Scalar,
-        pk: AffinePoint,
-        c: AffinePoint,
-    ) -> Result<Self, Error> {
-        // Initialize the Bid with the fields we were provided.
-        let mut bid = Bid {
-            bid_tree_root,
-            consensus_round_seed,
-            latest_consensus_round,
-            latest_consensus_step,
-            elegibility_ts,
-            expiration_ts,
-            prover_id: Scalar::default(),
-            score: Score::default(),
-            blinder,
-            encrypted_blinder,
-            value,
-            encrypted_value,
-            randomness,
-            secret_k,
-            hashed_secret,
-            pk,
-            c,
-        };
+    pub fn init(mut self) -> Result<Self, Error> {
         // Compute and add to the Bid the `prover_id`.
-        bid.generate_prover_id();
+        self.generate_prover_id();
         // Compute score and append it to the Bid.
-        bid.score = compute_score(&bid)?;
+        self.score = compute_score(&self)?;
 
-        Ok(bid)
+        Ok(self)
     }
 
     /// One-time prover-id is stated to be `H(secret_k, sigma^s, k^t, k^s)`.
@@ -112,11 +73,15 @@ impl Bid {
         ]);
     }
 
-    pub fn prove_score_generation(&self, composer: &mut StandardComposer) -> Result<Proof, Error> {
+    pub fn prove_score_generation(
+        &self,
+        composer: &mut StandardComposer,
+    ) -> Result<Proof, Error> {
         use crate::score_gen::score::prove_correct_score_gadget;
 
         prove_correct_score_gadget(composer, self)?;
-        // XXX: Return the proof with a pre-computed PreprocessedCircuit and ProverKey
+        // TODO: Return the proof with a pre-computed PreprocessedCircuit and
+        // ProverKey
         unimplemented!()
     }
 }

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -18,7 +18,7 @@ pub struct Bid {
     pub(crate) bid_tree_root: Scalar,
     // sigma^s
     pub(crate) consensus_round_seed: Scalar,
-    // k^r
+    // k^t
     pub(crate) latest_consensus_round: Scalar,
     // k^s
     pub(crate) latest_consensus_step: Scalar,
@@ -99,7 +99,7 @@ impl Bid {
         Ok(bid)
     }
 
-    /// One-time prover-id is stated to be H(secret_k, sigma^s, k^t, k^s).
+    /// One-time prover-id is stated to be `H(secret_k, sigma^s, k^t, k^s)`.
     ///
     /// The function performs the sponge_hash techniqe using poseidon to
     /// get the one-time prover_id and sets it in the Bid.

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -3,21 +3,11 @@
 //! See: https://hackmd.io/@7dpNYqjKQGeYC7wMlPxHtQ/BkfS78Y9L
 
 use super::Bid;
+use crate::jubjub_scalar_to_bls12_381;
 use dusk_bls12_381::Scalar;
 use dusk_plonk::constraint_system::{StandardComposer, Variable};
 use jubjub::{AffinePoint as JubJubAffine, Scalar as JubJubScalar};
 use poseidon252::{sponge::sponge::*, StorageScalar};
-
-// XXX: This should be moved to bls12_381 or jubjub lib.
-pub(self) fn jubjub_scalar_to_bls12_381(jubjub_scalar: JubJubScalar) -> Scalar {
-    let bytes = jubjub_scalar.to_bytes();
-    if bool::from(Scalar::from_bytes(&bytes).is_none()) == true {
-        panic!("Failed to convert a Scalar from JubJub to BLS Scalar field. Unexpected behaviour");
-    } else {
-        // Now it's safe to unwrap since we already know that the Choice will be correct.
-        return Scalar::from_bytes(&bytes).unwrap();
-    }
-}
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct StorageBid {
@@ -54,17 +44,17 @@ impl From<&Bid> for StorageBid {
     }
 }
 
-/// Encodes a `StorageBid` in a `StorageScalar` form by applying the correct encoding methods
-/// and collapsing it into a `StorageScalar` which can be then stored inside of a
-/// `kelvin` tree data structure.
+/// Encodes a `StorageBid` in a `StorageScalar` form by applying the correct
+/// encoding methods and collapsing it into a `StorageScalar` which can be then
+/// stored inside of a `kelvin` tree data structure.
 impl Into<StorageScalar> for StorageBid {
     fn into(self) -> StorageScalar {
-        // Generate an empty vector of `Scalar` which will store the representation
-        // of all of the `Bid` elements.
+        // Generate an empty vector of `Scalar` which will store the
+        // representation of all of the `Bid` elements.
         let mut words_deposit = Vec::new();
         // Note that the merkle_tree_root is not used since we can't pre-compute
-        // it. Therefore, any field that relies on it to be computed isn't neither
-        // used to obtain this encoded form.
+        // it. Therefore, any field that relies on it to be computed isn't
+        // neither used to obtain this encoded form.
 
         // 1. Generate the type_fields Scalar Id:
         // Type 1 will be BlsScalar
@@ -74,17 +64,21 @@ impl Into<StorageScalar> for StorageBid {
         // Byte-types are treated in Little Endian.
 
         // Safe unwrap here.
-        let type_fields = Scalar::from_bytes(b"44223133000000000000000000000000").unwrap();
+        let type_fields =
+            Scalar::from_bytes(b"44223133000000000000000000000000").unwrap();
         words_deposit.push(type_fields);
 
         // 2. Encode each word.
-        // Scalar and any other type that can be embedded in, will also be treated as one.
+        // Scalar and any other type that can be embedded in, will also be
+        // treated as one.
         words_deposit.push(Scalar::from(self.elegibility_ts as u64));
         words_deposit.push(Scalar::from(self.expiration_ts as u64));
-        // Unwraping a conversion between JubJubScalar to BlsScalar is always safe since the order of
-        // the JubJubScalar field is shorter than the BlsScalar one.
+
+        // A conversion between JubJubScalar to BlsScalar is always safe since
+        // the order of a JubJubScalar field is shorter than a BlsScalar one.
         words_deposit.push(jubjub_scalar_to_bls12_381(self.encrypted_blinder));
         words_deposit.push(jubjub_scalar_to_bls12_381(self.encrypted_value));
+
         // Push both JubJubAffine coordinates as a Scalar.
         words_deposit.push(self.randomness.get_x());
         words_deposit.push(self.randomness.get_y());
@@ -98,32 +92,45 @@ impl Into<StorageScalar> for StorageBid {
         words_deposit.push(self.c.get_x());
         words_deposit.push(self.c.get_y());
 
-        // Once all of the words are translated as `Scalar` and stored correctly,
-        // apply the Poseidon sponge hash function to obtain the encoded form of the
-        // `Bid`.
+        // Once all of the words are translated as `Scalar` and stored
+        // correctly, apply the Poseidon sponge hash function to obtain
+        // the encoded form of the `Bid`.
         StorageScalar(sponge_hash(&words_deposit))
     }
 }
 
 impl StorageBid {
-    /// Applies a preimage_gadget to the `StorageBid` fields hashing them and constraining
-    /// the result of the sponge hash to the real/expected `StorageBid` encoded value
-    /// expressed as `Scalar/StorageScalar`.
+    /// Applies a preimage_gadget to the `StorageBid` fields hashing them and
+    /// constraining the result of the sponge hash to the real/expected
+    /// `StorageBid` encoded value expressed as `Scalar/StorageScalar`.
     ///
     /// The expected encoded value is a Public Input for this circuit.
     /// Appart from that, the preimage_gadget hashing result is returned.
-    pub(crate) fn preimage_gadget(&self, composer: &mut StandardComposer) -> Variable {
-        // This field represents the types of the inputs and has to be the same as the
-        // default one.
-        // It has been already checked that it's safe to unwrap here since the value fits correctly in a `Scalar`.
-        let type_fields = Scalar::from_bytes(b"44223133000000000000000000000000").unwrap();
+    pub(crate) fn preimage_gadget(
+        &self,
+        composer: &mut StandardComposer,
+    ) -> Variable {
+        // This field represents the types of the inputs and has to be the same
+        // as the default one.
+        // It has been already checked that it's safe to unwrap here since the
+        // value fits correctly in a `Scalar`.
+        let type_fields =
+            Scalar::from_bytes(b"44223133000000000000000000000000").unwrap();
         // Add to the composer the values required for the preimage.
         let mut messages: Vec<Variable> = vec![];
         messages.push(composer.add_input(type_fields));
-        messages.push(composer.add_input(Scalar::from(self.elegibility_ts as u64)));
-        messages.push(composer.add_input(Scalar::from(self.expiration_ts as u64)));
-        messages.push(composer.add_input(jubjub_scalar_to_bls12_381(self.encrypted_blinder)));
-        messages.push(composer.add_input(jubjub_scalar_to_bls12_381(self.encrypted_value)));
+        messages
+            .push(composer.add_input(Scalar::from(self.elegibility_ts as u64)));
+        messages
+            .push(composer.add_input(Scalar::from(self.expiration_ts as u64)));
+        messages.push(
+            composer
+                .add_input(jubjub_scalar_to_bls12_381(self.encrypted_blinder)),
+        );
+        messages.push(
+            composer
+                .add_input(jubjub_scalar_to_bls12_381(self.encrypted_value)),
+        );
         messages.push(composer.add_input(self.randomness.get_x()));
         messages.push(composer.add_input(self.randomness.get_y()));
         messages.push(composer.add_input(self.hashed_secret));
@@ -137,7 +144,11 @@ impl StorageBid {
         // Constraint the hash to be equal to the real one
         let real_hash: StorageScalar = self.clone().into();
         let real_hash: Scalar = real_hash.into();
-        composer.constrain_to_constant(storage_bid_hash, Scalar::zero(), -real_hash);
+        composer.constrain_to_constant(
+            storage_bid_hash,
+            Scalar::zero(),
+            -real_hash,
+        );
         storage_bid_hash
     }
 }
@@ -145,9 +156,10 @@ impl StorageBid {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::*;
+    use crate::score_gen::Score;
     use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
     use dusk_plonk::fft::EvaluationDomain;
+    use failure::Error;
     use jubjub::{AffinePoint, Scalar as JubJubScalar};
     use merlin::Transcript;
     use rand_core::RngCore;
@@ -155,53 +167,65 @@ mod tests {
     #[ignore]
     #[test]
     fn test_word_padding() {
-        // This cannot be tested until we don't get propper test vectors from the research side.
+        // This cannot be tested until we don't get propper test vectors from
+        // the research side.
     }
 
     #[test]
-    fn storage_bid_preimage_gadget() {
+    fn storage_bid_preimage_gadget() -> Result<(), Error> {
         // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
         let mut composer = StandardComposer::new();
         let mut transcript = Transcript::new(b"TEST");
 
         // Generate a correct Bid
         let storage_bid = StorageBid::from(
-            &Bid::new(
-                Scalar::random(&mut rand::thread_rng()),
-                Scalar::random(&mut rand::thread_rng()),
-                Scalar::random(&mut rand::thread_rng()),
-                Scalar::random(&mut rand::thread_rng()),
-                rand::thread_rng().next_u32(),
-                rand::thread_rng().next_u32(),
-                JubJubScalar::from(99u64),
-                JubJubScalar::from(199u64),
-                JubJubScalar::from(6546546u64),
-                JubJubScalar::from(655588855476u64),
-                AffinePoint::identity(),
-                Scalar::random(&mut rand::thread_rng()),
-                Scalar::random(&mut rand::thread_rng()),
-                AffinePoint::identity(),
-                AffinePoint::identity(),
-            )
-            .unwrap(),
+            &Bid {
+                bid_tree_root: Scalar::random(&mut rand::thread_rng()),
+                consensus_round_seed: Scalar::random(&mut rand::thread_rng()),
+                latest_consensus_round: Scalar::random(&mut rand::thread_rng()),
+                latest_consensus_step: Scalar::random(&mut rand::thread_rng()),
+                elegibility_ts: rand::thread_rng().next_u32(),
+                expiration_ts: rand::thread_rng().next_u32(),
+                prover_id: Scalar::default(),
+                score: Score::default(),
+                blinder: JubJubScalar::from(99u64),
+                encrypted_blinder: JubJubScalar::from(199u64),
+                value: JubJubScalar::from(6546546u64),
+                encrypted_value: JubJubScalar::from(655588855476u64),
+                randomness: AffinePoint::identity(),
+                secret_k: Scalar::random(&mut rand::thread_rng()),
+                hashed_secret: Scalar::random(&mut rand::thread_rng()),
+                pk: AffinePoint::identity(),
+                c: AffinePoint::identity(),
+            }
+            .init()?,
         );
 
         // Apply the preimage_gadget
         let _ = storage_bid.preimage_gadget(&mut composer);
 
-        // Since we don't use all of the wires, we set some dummy constraints to avoid Committing
-        // to zero polynomials.
+        // Since we don't use all of the wires, we set some dummy constraints to
+        // avoid Committing to zero polynomials.
         composer.add_dummy_constraints();
 
         let prep_circ = composer.preprocess(
             &ck,
             &mut transcript,
-            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+            &EvaluationDomain::new(composer.circuit_size())
+                .expect("Evaluation Domain instance"),
         );
 
         let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
-        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
+        assert!(proof.verify(
+            &prep_circ,
+            &mut transcript,
+            &vk,
+            &composer.public_inputs()
+        ));
+
+        Ok(())
     }
 }

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -46,7 +46,7 @@ impl From<&Bid> for StorageBid {
 /// Encodes a `StorageBid` in a `StorageScalar` form by applying the correct encoding methods
 /// and collapsing it into a `StorageScalar` which can be then stored inside of a
 /// `kelvin` tree data structure.
-impl Into<StorageScalar> for &StorageBid {
+impl Into<StorageScalar> for StorageBid {
     fn into(self) -> StorageScalar {
         // Generate an empty vector of `Scalar` which will store the representation
         // of all of the `Bid` elements.
@@ -94,19 +94,110 @@ impl Into<StorageScalar> for &StorageBid {
     }
 }
 
+impl StorageBid {
+    /// Applies a preimage_gadget to the `StorageBid` fields hashing them and constraining
+    /// the result of the sponge hash to the real/expected `StorageBid` encoded value
+    /// expressed as `Scalar/StorageScalar`.
+    ///
+    /// The expected encoded value is a Public Input for this circuit.
+    /// Appart from that, the preimage_gadget hashing result is returned.
+    pub(crate) fn preimage_gadget(&self, composer: &mut StandardComposer) -> Variable {
+        // This field represents the types of the inputs and has to be the same as the
+        // default one.
+        let type_fields = Scalar::from_bytes(b"44223133000000000000000000000000").unwrap();
+        // Add to the composer the values required for the preimage.
+        let mut messages: Vec<Variable> = vec![];
+        messages.push(composer.add_input(type_fields));
+        messages.push(composer.add_input(Scalar::from(self.elegibility_ts as u64)));
+        messages.push(composer.add_input(Scalar::from(self.expiration_ts as u64)));
+        messages.push(
+            composer.add_input(Scalar::from_bytes(&self.encrypted_blinder.to_bytes()).unwrap()),
+        );
+        messages.push(
+            composer.add_input(Scalar::from_bytes(&self.encrypted_value.to_bytes()).unwrap()),
+        );
+        messages.push(
+            composer.add_input(Scalar::from_bytes(&self.randomness.get_x().to_bytes()).unwrap()),
+        );
+        messages.push(
+            composer.add_input(Scalar::from_bytes(&self.randomness.get_y().to_bytes()).unwrap()),
+        );
+        messages.push(composer.add_input(self.hashed_secret));
+        messages.push(composer.add_input(Scalar::from_bytes(&self.pk.get_x().to_bytes()).unwrap()));
+        messages.push(composer.add_input(Scalar::from_bytes(&self.pk.get_y().to_bytes()).unwrap()));
+        messages.push(composer.add_input(Scalar::from_bytes(&self.c.get_x().to_bytes()).unwrap()));
+        messages.push(composer.add_input(Scalar::from_bytes(&self.c.get_y().to_bytes()).unwrap()));
+
+        // Perform the sponge_hash inside of the Constraint System
+        let storage_bid_hash = sponge_hash_gadget(composer, &messages);
+        // Constraint the hash to be equal to the real one
+        let real_hash: StorageScalar = self.clone().into();
+        let real_hash: Scalar = real_hash.into();
+        composer.constrain_to_constant(storage_bid_hash, Scalar::zero(), -real_hash);
+        storage_bid_hash
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use super::*;
-    use dusk_bls12_381::G1Affine;
     use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
     use dusk_plonk::fft::EvaluationDomain;
     use jubjub::{AffinePoint, Scalar as JubJubScalar};
     use merlin::Transcript;
+    use rand_core::RngCore;
 
     #[ignore]
     #[test]
     fn test_word_padding() {
         // This cannot be tested until we don't get propper test vectors from the research side.
+    }
+
+    #[test]
+    fn storage_bid_preimage_gadget() {
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut composer = StandardComposer::new();
+        let mut transcript = Transcript::new(b"TEST");
+
+        // Generate a correct Bid
+        let storage_bid = StorageBid::from(
+            &Bid::new(
+                Scalar::random(&mut rand::thread_rng()),
+                Scalar::random(&mut rand::thread_rng()),
+                Scalar::random(&mut rand::thread_rng()),
+                Scalar::random(&mut rand::thread_rng()),
+                rand::thread_rng().next_u32(),
+                rand::thread_rng().next_u32(),
+                JubJubScalar::from(99u64),
+                JubJubScalar::from(199u64),
+                JubJubScalar::from(6546546u64),
+                JubJubScalar::from(655588855476u64),
+                AffinePoint::identity(),
+                Scalar::random(&mut rand::thread_rng()),
+                Scalar::random(&mut rand::thread_rng()),
+                AffinePoint::identity(),
+                AffinePoint::identity(),
+            )
+            .unwrap(),
+        );
+
+        // Apply the preimage_gadget
+        let _ = storage_bid.preimage_gadget(&mut composer);
+
+        // Since we don't use all of the wires, we set some dummy constraints to avoid Committing
+        // to zero polynomials.
+        composer.add_dummy_constraints();
+
+        let prep_circ = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
+        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
     }
 }

--- a/src/bid/mod.rs
+++ b/src/bid/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod bid;
 pub use bid::Bid;
 pub(crate) mod encoding;
+pub use encoding::StorageBid;

--- a/src/bid/mod.rs
+++ b/src/bid/mod.rs
@@ -1,4 +1,0 @@
-pub(crate) mod bid;
-pub use bid::Bid;
-pub(crate) mod encoding;
-pub use encoding::StorageBid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,18 @@ pub mod score_gen;
 pub const V_MIN: u64 = 50_000;
 /// The maximum amount user is permitted to bid
 pub const V_MAX: u64 = 250_000;
+
+// TODO:
+// Temporary at crate level, since this should be moved to bls12_381 or jubjub
+// lib
+pub(crate) fn jubjub_scalar_to_bls12_381(
+    jubjub_scalar: jubjub::Scalar,
+) -> dusk_bls12_381::Scalar {
+    let scalar = dusk_bls12_381::Scalar::from_bytes(&jubjub_scalar.to_bytes());
+
+    if scalar.is_none().into() {
+        panic!("Failed to convert a Scalar from JubJub to BLS Scalar field.");
+    }
+
+    scalar.unwrap()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bid;
 pub mod proof;
 pub mod score_gen;
 
-
-pub const v_min: u64 = 50_000;
-pub const v_max: u64 = 250_000;
+/// The minimum amount user is permitted to bid
+pub const V_MIN: u64 = 50_000;
+/// The maximum amount user is permitted to bid
+pub const V_MAX: u64 = 250_000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,7 @@
 pub mod bid;
 pub mod proof;
 pub mod score_gen;
+
+
+pub const v_min: u64 = 50_000;
+pub const v_max: u64 = 250_000;

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,13 +1,14 @@
 //! BlindBidProof module.
-//!
 
 use crate::bid::{Bid, StorageBid};
+use crate::jubjub_scalar_to_bls12_381;
 use crate::score_gen::*;
 use dusk_bls12_381::Scalar;
 use dusk_plonk::constraint_system::StandardComposer;
 use failure::Error;
 use poseidon252::{
-    merkle_proof::merkle_opening_gadget, sponge::sponge::*, PoseidonBranch, StorageScalar,
+    merkle_proof::merkle_opening_gadget, sponge::sponge::*, PoseidonBranch,
+    StorageScalar,
 };
 
 /// Generates the proof of BlindBid
@@ -18,7 +19,7 @@ pub fn blind_bid_proof(
 ) -> Result<(), Error> {
     // Get the corresponding `StorageBid` value that for the `Bid`
     // which is effectively the value of the proven leaf.
-    let storage_bid: StorageBid = StorageBid::from(bid);
+    let storage_bid = StorageBid::from(bid);
     let encoded_bid: StorageScalar = storage_bid.into();
     let proven_leaf = composer.add_input(encoded_bid.into());
     // 1. Merkle Opening
@@ -42,24 +43,25 @@ pub fn blind_bid_proof(
     // 5. c = C(v, b) Pedersen Commitment check
     // XXX: Unimplemented until we have ECC gate.
 
+    let bid_value = jubjub_scalar_to_bls12_381(bid.value);
     // 6. v_min < v <= v_max
-    // 0 < v -> XXX: Needs review
+    // 0 < v -> TODO: Needs review
     single_complex_range_proof(
         composer,
         Scalar::from(crate::V_MIN),
-        Scalar::from_bytes(&bid.value.to_bytes()).unwrap(),
+        bid_value,
     )?;
     // v <= v_max
     single_complex_range_proof(
         composer,
-        Scalar::from_bytes(&bid.value.to_bytes()).unwrap(),
+        bid_value,
         Scalar::from(crate::V_MAX),
     )?;
 
     // 7. 0 < value <= 2^64 range check
-    // Here is safe to unwrap since the order of the JubJub scalar field is shorter than the
-    // BLS12_381 one.
-    let value = composer.add_input(Scalar::from_bytes(&bid.value.to_bytes()).unwrap());
+    // Here is safe to unwrap since the order of the JubJub scalar field is
+    // shorter than the BLS12_381 one.
+    let value = composer.add_input(bid_value);
     // v < 2^64
     composer.range_gate(value, 64usize);
 
@@ -68,13 +70,18 @@ pub fn blind_bid_proof(
     let secret_k_hash = sponge_hash_gadget(composer, &[secret_k]);
     // Constraint the secret_k_hash to be equal to the publicly avaliable one.
     // This will introduce a Public Input to the circuit.
-    composer.constrain_to_constant(secret_k_hash, Scalar::zero(), -sponge_hash(&[bid.secret_k]));
+    composer.constrain_to_constant(
+        secret_k_hash,
+        Scalar::zero(),
+        -sponge_hash(&[bid.secret_k]),
+    );
 
     // 8. `prover_id = H(secret_k, sigma^s, k^t, k^s)`. Preimage check
     let sigma_s = composer.add_input(bid.consensus_round_seed);
     let k_t = composer.add_input(bid.latest_consensus_round);
     let k_s = composer.add_input(bid.latest_consensus_step);
-    let prover_id = sponge_hash_gadget(composer, &[secret_k, sigma_s, k_t, k_s]);
+    let prover_id =
+        sponge_hash_gadget(composer, &[secret_k, sigma_s, k_t, k_s]);
     // Constraint the computed prover_id to the expected & stored one.
     // This will introduce `prover_id` as a public input for the circuit.
     composer.constrain_to_constant(prover_id, Scalar::zero(), -bid.prover_id);
@@ -98,10 +105,11 @@ mod tests {
     use rand_core::RngCore;
 
     #[test]
-    fn correct_blindbid_proof() {
+    fn correct_blindbid_proof() -> Result<(), Error> {
         // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
         let mut composer = StandardComposer::new();
         let mut transcript = Transcript::new(b"TEST");
 
@@ -109,47 +117,61 @@ mod tests {
         let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
 
         // Generate a correct Bid
-        let bid = Bid::new(
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            rand::thread_rng().next_u32(),
-            rand::thread_rng().next_u32(),
-            JubJubScalar::from(99u64),
-            JubJubScalar::from(199u64),
-            JubJubScalar::from(6546546u64),
-            JubJubScalar::from(655588855476u64),
-            AffinePoint::identity(),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            AffinePoint::identity(),
-            AffinePoint::identity(),
-        )
-        .expect("Bid creation should not fail independently of the parameters send");
+        let bid = Bid {
+            bid_tree_root: Scalar::random(&mut rand::thread_rng()),
+            consensus_round_seed: Scalar::random(&mut rand::thread_rng()),
+            latest_consensus_round: Scalar::random(&mut rand::thread_rng()),
+            latest_consensus_step: Scalar::random(&mut rand::thread_rng()),
+            elegibility_ts: rand::thread_rng().next_u32(),
+            expiration_ts: rand::thread_rng().next_u32(),
+            prover_id: Scalar::default(),
+            score: Score::default(),
+            blinder: JubJubScalar::from(99u64),
+            encrypted_blinder: JubJubScalar::from(199u64),
+            value: JubJubScalar::from(6546546u64),
+            encrypted_value: JubJubScalar::from(655588855476u64),
+            randomness: AffinePoint::identity(),
+            secret_k: Scalar::random(&mut rand::thread_rng()),
+            hashed_secret: Scalar::random(&mut rand::thread_rng()),
+            pk: AffinePoint::identity(),
+            c: AffinePoint::identity(),
+        }
+        .init()?;
+
         // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(StorageBid::from(&bid).into()).unwrap();
+        tree.push(StorageBid::from(&bid).into())?;
 
         // Extract the branch
-        let branch = tree.poseidon_branch(0u64).unwrap().unwrap();
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
 
-        blind_bid_proof(&mut composer, &bid, &branch).unwrap();
+        blind_bid_proof(&mut composer, &bid, &branch)?;
         let prep_circ = composer.preprocess(
             &ck,
             &mut transcript,
-            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+            &EvaluationDomain::new(composer.circuit_size())
+                .expect("Evaluation Domain instance"),
         );
 
         let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
 
-        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
+        assert!(proof.verify(
+            &prep_circ,
+            &mut transcript,
+            &vk,
+            &composer.public_inputs()
+        ));
+
+        Ok(())
     }
 
     #[test]
-    fn incorrect_blindbid_proof() {
+    fn incorrect_blindbid_proof() -> Result<(), Error> {
         // Generate Composer & Public Parameters
-        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
-        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
         let mut composer = StandardComposer::new();
         let mut transcript = Transcript::new(b"TEST");
 
@@ -157,43 +179,57 @@ mod tests {
         let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
 
         // Generate a correct Bid
-        let mut bid = Bid::new(
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            rand::thread_rng().next_u32(),
-            rand::thread_rng().next_u32(),
-            JubJubScalar::from(99u64),
-            JubJubScalar::from(199u64),
-            JubJubScalar::from(6546546u64),
-            JubJubScalar::from(655588855476u64),
-            AffinePoint::identity(),
-            Scalar::random(&mut rand::thread_rng()),
-            Scalar::random(&mut rand::thread_rng()),
-            AffinePoint::identity(),
-            AffinePoint::identity(),
-        )
-        .unwrap();
+        let mut bid = Bid {
+            bid_tree_root: Scalar::random(&mut rand::thread_rng()),
+            consensus_round_seed: Scalar::random(&mut rand::thread_rng()),
+            latest_consensus_round: Scalar::random(&mut rand::thread_rng()),
+            latest_consensus_step: Scalar::random(&mut rand::thread_rng()),
+            elegibility_ts: rand::thread_rng().next_u32(),
+            expiration_ts: rand::thread_rng().next_u32(),
+            prover_id: Scalar::default(),
+            score: Score::default(),
+            blinder: JubJubScalar::from(99u64),
+            encrypted_blinder: JubJubScalar::from(199u64),
+            value: JubJubScalar::from(6546546u64),
+            encrypted_value: JubJubScalar::from(655588855476u64),
+            randomness: AffinePoint::identity(),
+            secret_k: Scalar::random(&mut rand::thread_rng()),
+            hashed_secret: Scalar::random(&mut rand::thread_rng()),
+            pk: AffinePoint::identity(),
+            c: AffinePoint::identity(),
+        }
+        .init()?;
+
         // Edit the Bid structure to cheat by incrementing the Score.
         bid.score.score = -Scalar::one();
         // Edit the Bid structure by editing the expiration_ts.
         bid.expiration_ts = 13256586u32;
         // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(StorageBid::from(&bid).into()).unwrap();
+        tree.push(StorageBid::from(&bid).into())?;
 
         // Extract the branch
-        let branch = tree.poseidon_branch(0u64).unwrap().unwrap();
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
 
-        blind_bid_proof(&mut composer, &bid, &branch).unwrap();
+        blind_bid_proof(&mut composer, &bid, &branch)?;
+
         let prep_circ = composer.preprocess(
             &ck,
             &mut transcript,
-            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+            &EvaluationDomain::new(composer.circuit_size())
+                .expect("Evaluation Domain instance"),
         );
 
         let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
 
-        assert!(!proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
+        assert!(!proof.verify(
+            &prep_circ,
+            &mut transcript,
+            &vk,
+            &composer.public_inputs()
+        ));
+
+        Ok(())
     }
 }

--- a/src/proof/blindbid_proof.rs
+++ b/src/proof/blindbid_proof.rs
@@ -1,9 +1,199 @@
 //! BlindBidProof module.
 //!
 
-use crate::bid::Bid;
+use crate::bid::{Bid, StorageBid};
+use crate::score_gen::*;
+use dusk_bls12_381::Scalar;
 use dusk_plonk::constraint_system::StandardComposer;
+use failure::Error;
+use poseidon252::{
+    merkle_proof::merkle_opening_gadget, sponge::sponge::*, PoseidonBranch, StorageScalar,
+};
 
-pub fn blind_bid_proof(composer: &mut StandardComposer, bid: &Bid) {
-    unimplemented!()
+pub fn blind_bid_proof(
+    composer: &mut StandardComposer,
+    bid: &Bid,
+    branch: &PoseidonBranch,
+) -> Result<(), Error> {
+    // Get the corresponding `StorageBid` value that for the `Bid`
+    // which is effectively the value of the proven leaf.
+    let storage_bid: StorageBid = StorageBid::from(bid).into();
+    let encoded_bid: StorageScalar = storage_bid.into();
+    let proven_leaf = composer.add_input(encoded_bid.into());
+    // 1. Merkle Opening
+    merkle_opening_gadget(composer, branch.clone(), proven_leaf, branch.root);
+    // 2. Bid pre_image check
+    storage_bid.preimage_gadget(composer);
+    // 3. k_t <= t_a range check XXX: Needs review!
+    single_complex_range_proof(
+        composer,
+        Scalar::from(bid.elegibility_ts as u64),
+        bid.latest_consensus_step,
+    )?;
+
+    // 4. t_e <= k_t
+    single_complex_range_proof(
+        composer,
+        Scalar::from(bid.expiration_ts as u64),
+        bid.latest_consensus_step,
+    )?;
+
+    // 5. c = C(v, b) Pedersen Commitment check
+    // XXX: Unimplemented until we have ECC gate.
+
+    // 6. v_min < v <= v_max
+    // 0 < v -> XXX: Needs review
+    single_complex_range_proof(
+        composer,
+        Scalar::from(crate::v_min),
+        Scalar::from_bytes(&bid.value.to_bytes()).unwrap(),
+    )?;
+    // v <= v_max
+    single_complex_range_proof(
+        composer,
+        Scalar::from_bytes(&bid.value.to_bytes()).unwrap(),
+        Scalar::from(crate::v_max),
+    )?;
+
+    // 7. 0 < value <= 2^64 range check
+    // Here is safe to unwrap since the order of the JubJub scalar field is shorter than the
+    // BLS12_381 one.
+    let value = composer.add_input(Scalar::from_bytes(&bid.value.to_bytes()).unwrap());
+    // v < 2^64
+    composer.range_gate(value, 64usize);
+
+    // 7. `m = H(k)` Secret key pre-image check.
+    let secret_k = composer.add_input(bid.secret_k);
+    let secret_k_hash = sponge_hash_gadget(composer, &[secret_k]);
+    // Constraint the secret_k_hash to be equal to the publicly avaliable one.
+    // This will introduce a Public Input to the circuit.
+    composer.constrain_to_constant(secret_k_hash, Scalar::zero(), -sponge_hash(&[bid.secret_k]));
+
+    // 8. `prover_id = H(secret_k, sigma^s, k^t, k^s)`. Preimage check
+    let sigma_s = composer.add_input(bid.consensus_round_seed);
+    let k_t = composer.add_input(bid.latest_consensus_round);
+    let k_s = composer.add_input(bid.latest_consensus_step);
+    let prover_id = sponge_hash_gadget(composer, &[secret_k, sigma_s, k_t, k_s]);
+    // Constraint the computed prover_id to the expected & stored one.
+    // This will introduce `prover_id` as a public input for the circuit.
+    composer.constrain_to_constant(prover_id, Scalar::zero(), -bid.prover_id);
+
+    // 9. Score generation circuit check with the corresponding gadget.
+    prove_correct_score_gadget(composer, bid)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dusk_plonk::commitment_scheme::kzg10::PublicParameters;
+    use dusk_plonk::constraint_system::StandardComposer;
+    use dusk_plonk::fft::EvaluationDomain;
+    use jubjub::{AffinePoint, Fr as JubJubScalar};
+    use kelvin::Blake2b;
+    use merlin::Transcript;
+    use poseidon252::PoseidonTree;
+    use rand_core::RngCore;
+
+    #[test]
+    fn correct_blindbid_proof() {
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut composer = StandardComposer::new();
+        let mut transcript = Transcript::new(b"TEST");
+
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+
+        // Generate a correct Bid
+        let bid = Bid::new(
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            rand::thread_rng().next_u32(),
+            rand::thread_rng().next_u32(),
+            JubJubScalar::from(99u64),
+            JubJubScalar::from(199u64),
+            JubJubScalar::from(6546546u64),
+            JubJubScalar::from(655588855476u64),
+            AffinePoint::identity(),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            AffinePoint::identity(),
+            AffinePoint::identity(),
+        )
+        .unwrap();
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(StorageBid::from(&bid).into()).unwrap();
+
+        // Extract the branch
+        let branch = tree.poseidon_branch(0u64).unwrap().unwrap();
+
+        blind_bid_proof(&mut composer, &bid, &branch).unwrap();
+        println!("{:?}", composer.circuit_size());
+        let prep_circ = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
+
+        assert!(proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
+    }
+
+    #[test]
+    fn incorrect_blindbid_proof() {
+        // Generate Composer & Public Parameters
+        let pub_params = PublicParameters::setup(1 << 17, &mut rand::thread_rng()).unwrap();
+        let (ck, vk) = pub_params.trim(1 << 16).unwrap();
+        let mut composer = StandardComposer::new();
+        let mut transcript = Transcript::new(b"TEST");
+
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+
+        // Generate a correct Bid
+        let mut bid = Bid::new(
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            rand::thread_rng().next_u32(),
+            rand::thread_rng().next_u32(),
+            JubJubScalar::from(99u64),
+            JubJubScalar::from(199u64),
+            JubJubScalar::from(6546546u64),
+            JubJubScalar::from(655588855476u64),
+            AffinePoint::identity(),
+            Scalar::random(&mut rand::thread_rng()),
+            Scalar::random(&mut rand::thread_rng()),
+            AffinePoint::identity(),
+            AffinePoint::identity(),
+        )
+        .unwrap();
+        // Edit the Bid structure to cheat by incrementing the Score.
+        bid.score.score = -Scalar::one();
+        // Edit the Bid structure by editing the expiration_ts.
+        bid.expiration_ts = 13256586u32;
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(StorageBid::from(&bid).into()).unwrap();
+
+        // Extract the branch
+        let branch = tree.poseidon_branch(0u64).unwrap().unwrap();
+
+        blind_bid_proof(&mut composer, &bid, &branch).unwrap();
+        let prep_circ = composer.preprocess(
+            &ck,
+            &mut transcript,
+            &EvaluationDomain::new(composer.circuit_size()).unwrap(),
+        );
+
+        let proof = composer.prove(&ck, &prep_circ, &mut transcript.clone());
+
+        assert!(!proof.verify(&prep_circ, &mut transcript, &vk, &composer.public_inputs()));
+    }
 }

--- a/src/proof/blindbid_proof.rs
+++ b/src/proof/blindbid_proof.rs
@@ -18,7 +18,7 @@ pub fn blind_bid_proof(
 ) -> Result<(), Error> {
     // Get the corresponding `StorageBid` value that for the `Bid`
     // which is effectively the value of the proven leaf.
-    let storage_bid: StorageBid = StorageBid::from(bid).into();
+    let storage_bid: StorageBid = StorageBid::from(bid);
     let encoded_bid: StorageScalar = storage_bid.into();
     let proven_leaf = composer.add_input(encoded_bid.into());
     // 1. Merkle Opening
@@ -46,14 +46,14 @@ pub fn blind_bid_proof(
     // 0 < v -> XXX: Needs review
     single_complex_range_proof(
         composer,
-        Scalar::from(crate::v_min),
+        Scalar::from(crate::V_MIN),
         Scalar::from_bytes(&bid.value.to_bytes()).unwrap(),
     )?;
     // v <= v_max
     single_complex_range_proof(
         composer,
         Scalar::from_bytes(&bid.value.to_bytes()).unwrap(),
-        Scalar::from(crate::v_max),
+        Scalar::from(crate::V_MAX),
     )?;
 
     // 7. 0 < value <= 2^64 range check
@@ -126,7 +126,7 @@ mod tests {
             AffinePoint::identity(),
             AffinePoint::identity(),
         )
-        .unwrap();
+        .expect("Bid creation should not fail independently of the parameters send");
         // Append the StorageBid as an StorageScalar to the tree.
         tree.push(StorageBid::from(&bid).into()).unwrap();
 
@@ -134,7 +134,6 @@ mod tests {
         let branch = tree.poseidon_branch(0u64).unwrap().unwrap();
 
         blind_bid_proof(&mut composer, &bid, &branch).unwrap();
-        println!("{:?}", composer.circuit_size());
         let prep_circ = composer.preprocess(
             &ck,
             &mut transcript,

--- a/src/proof/blindbid_proof.rs
+++ b/src/proof/blindbid_proof.rs
@@ -10,6 +10,7 @@ use poseidon252::{
     merkle_proof::merkle_opening_gadget, sponge::sponge::*, PoseidonBranch, StorageScalar,
 };
 
+/// Generates the proof of BlindBid
 pub fn blind_bid_proof(
     composer: &mut StandardComposer,
     bid: &Bid,
@@ -27,14 +28,14 @@ pub fn blind_bid_proof(
     // 3. k_t <= t_a range check XXX: Needs review!
     single_complex_range_proof(
         composer,
-        Scalar::from(bid.elegibility_ts as u64),
+        Scalar::from(storage_bid.elegibility_ts as u64),
         bid.latest_consensus_step,
     )?;
 
     // 4. t_e <= k_t
     single_complex_range_proof(
         composer,
-        Scalar::from(bid.expiration_ts as u64),
+        Scalar::from(storage_bid.expiration_ts as u64),
         bid.latest_consensus_step,
     )?;
 

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -1,1 +1,0 @@
-pub mod blindbid_proof;

--- a/src/score_gen.rs
+++ b/src/score_gen.rs
@@ -1,0 +1,7 @@
+pub(crate) mod errors;
+pub mod score;
+pub(crate) use score::{
+    compute_score, prove_correct_score_gadget, single_complex_range_proof,
+};
+
+pub use score::Score;

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod errors;
 pub mod score;
-pub(crate) use score::compute_score;
+pub(crate) use score::{compute_score, prove_correct_score_gadget};
+
 pub use score::Score;

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod errors;
 pub mod score;
-pub(crate) use score::{compute_score, prove_correct_score_gadget};
+pub(crate) use score::{compute_score, prove_correct_score_gadget, single_complex_range_proof};
 
 pub use score::Score;

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -1,5 +1,0 @@
-pub(crate) mod errors;
-pub mod score;
-pub(crate) use score::{compute_score, prove_correct_score_gadget, single_complex_range_proof};
-
-pub use score::Score;

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -270,7 +270,7 @@ pub(crate) fn single_complex_range_proof(
     witness: Scalar,
     max_range: Scalar,
 ) -> Result<Variable, Error> {
-    let log = log_2_roudup(max_range);
+    let log = next_pow_2_bitnum(max_range);
     let closest_pow_of_two = Scalar::from(2u64).pow(&[log, 0, 0, 0]);
     // Compute b' max range.
     let b_prime = closest_pow_of_two - max_range;
@@ -395,7 +395,7 @@ fn scalar_to_bits(scalar: &Scalar) -> [u8; 256] {
     res
 }
 
-fn log_2_roudup(mut scalar: Scalar) -> u64 {
+fn next_pow_2_bitnum(mut scalar: Scalar) -> u64 {
     scalar = scalar.reduce();
     let mut counter = 0u64;
     while scalar > Scalar::one().reduce() {
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn log_2_rounded() {
         let two_pow_128 = Scalar::from(2u64).pow(&[128u64, 0, 0, 0]);
-        assert_eq!(log_2_roudup(two_pow_128), 129u64);
+        assert_eq!(next_pow_2_bitnum(two_pow_128), 129u64);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds the implementation of the BlindBidProof gadget which is the responsable of generating the BlindBidProof circuit.

Also includes test cases for correct and incorrect circuit declarations.

This implementation also includes a refactor on the `single_complex_rangeproof` gadget which now doesn't require to send the next pow of two as a parameter and also is generic enough to support every range you want to check.


Closes #3 
Closes #4 

NOTE:
- There are two `XXX` reminders since some of the range checks should be reviewed with Dmitry since they will maybe need another gadget.

## Results:
Atm the `circuit_size` for this proof is: 43942 constraints. This basically is the same as the next power of two (which is 2^16 constraints).
That means it will take approximately according to PLONK benchmarks:
```
CONSTRAINTS/# CIRCUIT_GATES = 2^16
Start:   Start Proof
End:     Start Proof ...............................................................4.857s
```