### PR TITLE
Add ECC-gate dependant constraints to the blindbid gadgets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-dusk-plonk = "0.2.0"
-hades252 = {git = "https://github.com/dusk-network/Hades252", tag = "v0.6.0"}
+dusk-plonk = "0.2.6"
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252"}
 failure = "0.1.7"
 kelvin = "0.13.0"

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -140,13 +140,11 @@ impl StorageBid {
         // Constraint the hash to be equal to the real one
         let real_hash: StorageScalar = self.clone().into();
         let real_hash: BlsScalar = real_hash.into();
-        let real_hash_var = composer.add_input(real_hash);
         composer.constrain_to_constant(
-            real_hash_var,
-            real_hash,
+            storage_bid_hash,
             BlsScalar::zero(),
+            -real_hash,
         );
-        composer.assert_equal(real_hash_var, storage_bid_hash);
         storage_bid_hash
     }
 }
@@ -196,7 +194,7 @@ mod tests {
                     encrypted_value: JubJubScalar::from(655588855476u64),
                     randomness: AffinePoint::identity(),
                     secret_k: BlsScalar::random(&mut rand::thread_rng()),
-                    hashed_secret: BlsScalar::random(&mut rand::thread_rng()),
+                    hashed_secret: BlsScalar::default(),
                     pk: AffinePoint::identity(),
                     c: AffinePoint::identity(),
                 }
@@ -213,6 +211,7 @@ mod tests {
         let mut verifier = Verifier::new(b"testing");
         storage_bid.preimage_gadget(verifier.mut_cs());
         verifier.preprocess(&ck)?;
-        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
+        let pi = verifier.mut_cs().public_inputs.clone();
+        verifier.verify(&proof, &vk, &pi)
     }
 }

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -311,9 +311,12 @@ pub(crate) fn single_complex_range_proof(
 
     let mut var_accumulator = zero;
 
-    let accumulator = bits[..num_bits as usize].iter().enumerate().fold(
+    let accumulator = bits[..].iter().enumerate().fold(
         BlsScalar::zero(),
-        |scalar_accum, (idx, bit)| {
+        |scalar_accum, (idx, mut bit)| {
+            if idx >= num_bits as usize {
+                bit = &0u8;
+            };
             let bit_var = composer.add_input(BlsScalar::from(*bit as u64));
             // Apply boolean constraint to the bit.
             composer.boolean_gate(bit_var);
@@ -569,7 +572,7 @@ mod tests {
             encrypted_value: JubJubScalar::from(655588855476u64),
             randomness: AffinePoint::identity(),
             secret_k: BlsScalar::random(&mut rand::thread_rng()),
-            hashed_secret: BlsScalar::random(&mut rand::thread_rng()),
+            hashed_secret: BlsScalar::default(),
             pk: AffinePoint::identity(),
             c: AffinePoint::identity(),
         }
@@ -611,7 +614,7 @@ mod tests {
             encrypted_value: JubJubScalar::from(655588855476u64),
             randomness: AffinePoint::identity(),
             secret_k: BlsScalar::random(&mut rand::thread_rng()),
-            hashed_secret: BlsScalar::random(&mut rand::thread_rng()),
+            hashed_secret: BlsScalar::default(),
             pk: AffinePoint::identity(),
             c: AffinePoint::identity(),
         }


### PR DESCRIPTION
As stated in #28 we were missing all of the ECC-gate-
dependant constraints inside of the blindbid gadgets.

With the new version of PLONK out, we were able to implement
& test them so that the Pedersen Commitments used inside are
correctly constructed and working.

Closes #28