### PR TITLE
Replace failiure with `Anyhow` & `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,15 @@ edition = "2018"
 
 
 [dependencies]
-dusk-plonk = {version = "0.2.6", features = ["trace-print"]}
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.0"}
-failure = "0.1.7"
+anyhow = "1.0.0"
+dusk-plonk = {version = "0.2.7", features = ["trace-print"]}
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.1"}
 kelvin = "0.13.0"
 num-bigint = "0.2.6"
 num-traits = "0.2.11"
+thiserror = "1.0.20"
 
 [dev-dependencies]
 rand = "0.7.3"
 rand_core = "0.5.1"
+

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -44,20 +44,20 @@ impl Bid {
     pub fn init(mut self, value: &JubJubScalar) -> Result<Self, Error> {
         // Check if the bid_value is in the correct range, otherways, fail.
         match (
-            value.reduce() > JubJubScalar::from(crate::V_MAX).reduce(),
-            value.reduce() < JubJubScalar::from(crate::V_MIN).reduce(),
+            value.reduce() > crate::V_MAX.reduce(),
+            value.reduce() < crate::V_MIN.reduce(),
         ) {
             (true, false) => {
                 return Err(BidGenerationError::MaximumBidValueExceeded {
-                    max_val: &JubJubScalar::from(crate::V_MAX),
-                    found: value,
+                    max_val: crate::V_MAX,
+                    found: *value,
                 }
                 .into());
             }
             (false, true) => {
                 return Err(BidGenerationError::MinimumBidValueUnreached {
-                    min_val: &JubJubScalar::from(crate::V_MIN),
-                    found: value,
+                    min_val: crate::V_MIN,
+                    found: *value,
                 }
                 .into());
             }

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -2,9 +2,9 @@
 
 use super::BidGenerationError;
 use crate::score_gen::{compute_score, Score};
+use anyhow::{Error, Result};
 use dusk_plonk::jubjub::AffinePoint;
 use dusk_plonk::prelude::*;
-use failure::Error;
 use poseidon252::sponge::sponge::sponge_hash;
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -48,10 +48,18 @@ impl Bid {
             value.reduce() < JubJubScalar::from(crate::V_MIN).reduce(),
         ) {
             (true, false) => {
-                return Err(BidGenerationError::MaximumBidValueExceeded.into());
+                return Err(BidGenerationError::MaximumBidValueExceeded {
+                    max_val: &JubJubScalar::from(crate::V_MAX),
+                    found: value,
+                }
+                .into());
             }
             (false, true) => {
-                return Err(BidGenerationError::MinimumBidValueUnreached.into());
+                return Err(BidGenerationError::MinimumBidValueUnreached {
+                    min_val: &JubJubScalar::from(crate::V_MIN),
+                    found: value,
+                }
+                .into());
             }
             (false, false) => (),
             (_, _) => unreachable!(),

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -161,8 +161,8 @@ impl StorageBid {
 mod tests {
     use super::*;
     use crate::score_gen::Score;
+    use anyhow::Result;
     use dusk_plonk::jubjub::{GENERATOR, GENERATOR_NUMS};
-    use failure::Error;
     use rand_core::RngCore;
 
     pub(self) fn gen_val_blinder_and_commitment(
@@ -185,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    fn storage_bid_preimage_gadget() -> Result<(), Error> {
+    fn storage_bid_preimage_gadget() -> Result<()> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;

--- a/src/bid/errors.rs
+++ b/src/bid/errors.rs
@@ -15,7 +15,7 @@ pub enum BidGenerationError<'a> {
         /// The maximum bid_value allowed
         max_val: &'a JubJubScalar,
         /// The expected length
-        found: &'a JubJubScalar,
+        found: JubJubScalar,
     },
     /// Error for the cases when we the provided Bid value is lower
     /// than the minimum allowed by the specs..
@@ -26,6 +26,6 @@ pub enum BidGenerationError<'a> {
         /// The minimum bid_value required
         min_val: &'a JubJubScalar,
         /// The expected length
-        found: &'a JubJubScalar,
+        found: JubJubScalar,
     },
 }

--- a/src/bid/errors.rs
+++ b/src/bid/errors.rs
@@ -1,16 +1,31 @@
 //! Errors related to the Bid Generation
 
-use failure::Fail;
+use dusk_plonk::jubjub::Fr as JubJubScalar;
+use thiserror::Error;
 
 /// Definition of the erros that Bid operations might have.
-#[derive(Fail, Debug)]
-pub enum BidGenerationError {
+#[derive(Error, Debug)]
+pub enum BidGenerationError<'a> {
     /// Error for the cases when we the provided Bid value is bigger
     /// than the maximum allowed by the specs..
-    #[fail(display = "maximum bid_value exceeded")]
-    MaximumBidValueExceeded,
+    #[error(
+        "maximum bid_value allowed is {max_val:?} but {found:?} was found"
+    )]
+    MaximumBidValueExceeded {
+        /// The maximum bid_value allowed
+        max_val: &'a JubJubScalar,
+        /// The expected length
+        found: &'a JubJubScalar,
+    },
     /// Error for the cases when we the provided Bid value is lower
     /// than the minimum allowed by the specs..
-    #[fail(display = "minimum bid_value not reached")]
-    MinimumBidValueUnreached,
+    #[error(
+        "minimum bid_value required is {min_val:?} but {found:?} was found"
+    )]
+    MinimumBidValueUnreached {
+        /// The minimum bid_value required
+        min_val: &'a JubJubScalar,
+        /// The expected length
+        found: &'a JubJubScalar,
+    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,10 @@ pub mod bid;
 pub mod proof;
 pub mod score_gen;
 
+use dusk_plonk::jubjub::Fr as JubJubScalar;
 /// The minimum amount user is permitted to bid
-pub const V_MIN: u64 = 50_000;
+pub const V_MIN: &'static JubJubScalar =
+    &JubJubScalar::from_raw([50_000u64, 0, 0, 0]);
 /// The maximum amount user is permitted to bid
-pub const V_MAX: u64 = 250_000;
+pub const V_MAX: &'static JubJubScalar =
+    &JubJubScalar::from_raw([250_000u64, 0, 0, 0]);

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -2,11 +2,11 @@
 
 use crate::bid::{Bid, StorageBid};
 use crate::score_gen::*;
+use anyhow::Result;
 use dusk_plonk::constraint_system::ecc::{
     curve_addition, gates::*, scalar_mul,
 };
 use dusk_plonk::prelude::*;
-use failure::Error;
 use poseidon252::{
     merkle_proof::merkle_opening_gadget, sponge::sponge::*, PoseidonBranch,
     StorageScalar,
@@ -19,7 +19,7 @@ pub fn blind_bid_proof(
     branch: &PoseidonBranch,
     value: JubJubScalar,
     blinder: JubJubScalar,
-) -> Result<(), Error> {
+) -> Result<()> {
     // Get the corresponding `StorageBid` value that for the `Bid`
     // which is effectively the value of the proven leaf.
     let storage_bid = StorageBid::from(bid);
@@ -46,8 +46,8 @@ pub fn blind_bid_proof(
 
     // 5. c = C(v, b) Pedersen Commitment check
     use dusk_plonk::jubjub::{ExtendedPoint, GENERATOR, GENERATOR_NUMS};
-    let bid_value = composer.add_constant_witness(value.into());
-    let blinder = composer.add_constant_witness(blinder.into());
+    let bid_value = composer.add_witness_to_circuit_description(value.into());
+    let blinder = composer.add_witness_to_circuit_description(blinder.into());
     let p1 = scalar_mul(composer, bid_value, ExtendedPoint::from(GENERATOR));
     let p2 = scalar_mul(composer, blinder, ExtendedPoint::from(GENERATOR_NUMS));
     let computed_c = curve_addition(composer, p1.into(), p2.into());
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    fn correct_blindbid_proof() -> Result<(), Error> {
+    fn correct_blindbid_proof() -> Result<()> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn edited_score_blindbid_proof() -> Result<(), Error> {
+    fn edited_score_blindbid_proof() -> Result<()> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
@@ -224,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn edited_bid_value_blindbid_proof() -> Result<(), Error> {
+    fn edited_bid_value_blindbid_proof() -> Result<()> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;

--- a/src/score_gen/errors.rs
+++ b/src/score_gen/errors.rs
@@ -1,15 +1,15 @@
 //! Errors related to the Score Generation
 
-use failure::Fail;
+use thiserror::Error;
 
 /// Definition of the erros that Bid operations might have.
-#[derive(Fail, Debug)]
+#[derive(Error, Debug)]
 pub enum ScoreError {
     /// Error for the cases when we the score results are too large to
     /// fit inside a `Scalar`.
-    #[fail(display = "score results do not fit inside of Scalar")]
+    #[error("score results do not fit inside of Scalar")]
     InvalidScoreFieldsLen,
     /// Error for computations of inverses that do not exists (non-Qr's)
-    #[fail(display = "Inverse of the Scalar does not exist")]
+    #[error("Inverse of the Scalar does not exist")]
     NonExistingInverse,
 }

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -2,8 +2,8 @@
 
 use super::errors::ScoreError;
 use crate::bid::Bid;
+use anyhow::{Error, Result};
 use dusk_plonk::prelude::*;
-use failure::Error;
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 use poseidon252::sponge::*;


### PR DESCRIPTION
We now use `anyhow` + `thiserror` in order to manage
the error handling of the crate.

The `errors.rs` file has been refactored and everything works
with `thiserror`'s derive macros. We also added field descriptions
for the errors.

- Refactored the tests to use `anyhow::Result`.
- Updated dusk-plonk to v0.2.7 & poseidon252 to v0.6.1