### PR TITLE
Refactor documentation upload script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ after_success:
 - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
       cargo doc --no-deps &&
-      echo "<meta http-equiv=refresh content=0;url=dusk_blindbid/index.html>" > target/doc/index.html &&
+      echo "<meta http-equiv=refresh content=0;url=blind_bid/index.html>" > target/doc/index.html &&
       git clone https://github.com/davisp/ghp-import.git &&
       ./ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc &&
       echo "Uploaded documentation"


### PR DESCRIPTION
The name of the repo was wrong and therefore we were not getting uploaded the correct `index.html` version for the docs of the library.

This PR solves it.