### PR TITLE
Import GENERATORS in extended coordinates directly

### DIFF
--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -162,7 +162,7 @@ mod tests {
     use super::*;
     use crate::score_gen::Score;
     use anyhow::Result;
-    use dusk_plonk::jubjub::{GENERATOR, GENERATOR_NUMS};
+    use dusk_plonk::jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
     use rand_core::RngCore;
 
     pub(self) fn gen_val_blinder_and_commitment(
@@ -171,8 +171,8 @@ mod tests {
         let blinder = JubJubScalar::random(&mut rand::thread_rng());
 
         let commitment: AffinePoint = AffinePoint::from(
-            &(GENERATOR.to_niels() * value)
-                + &(GENERATOR_NUMS.to_niels() * blinder),
+            &(GENERATOR_EXTENDED * value)
+                + &(GENERATOR_NUMS_EXTENDED * blinder),
         );
         (value, blinder, commitment)
     }

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -446,7 +446,9 @@ fn bits_count(mut scalar: BlsScalar) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dusk_plonk::jubjub::{AffinePoint, GENERATOR, GENERATOR_NUMS};
+    use dusk_plonk::jubjub::{
+        AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
+    };
     use rand_core::RngCore;
 
     pub(self) fn gen_val_blinder_and_commitment(
@@ -455,8 +457,8 @@ mod tests {
         let blinder = JubJubScalar::random(&mut rand::thread_rng());
 
         let commitment: AffinePoint = AffinePoint::from(
-            &(GENERATOR.to_niels() * value)
-                + &(GENERATOR_NUMS.to_niels() * blinder),
+            &(GENERATOR_EXTENDED * value)
+                + &(GENERATOR_NUMS_EXTENDED * blinder),
         );
         (value, blinder, commitment)
     }


### PR DESCRIPTION
In order to save time and not need to switch between
coordinates constantly, we directly import the generators
in Extended Coordinates.

Closes #42