### PR TITLE
Fix plonk_gadgets dependency in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.
 kelvin = "0.13.0"
 num-bigint = "0.2.6"
 num-traits = "0.2.11"
-plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", branch = "update_mod"}
+plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.2.0"}
 thiserror = "1.0.20"
 
 [dev-dependencies]


### PR DESCRIPTION
Me, @CPerezz prematurely merged #49 with a git dependency inside
that wasn't pointing to a tag/release. This is a bad practice and indeed
it can cause problems since now the branch refered in Cargo.toml
doesn't exist.

Therefore, now that we have the release, this PR updates the
`plonk_gadgets` dependency of ´dusk-blindbid` to the newest
tag `v0.2.0`.