### PR TITLE
Single Bid approach

### DIFF
--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -3,7 +3,7 @@
 //! Bid data structure
 
 use super::BidGenerationError;
-use crate::score_gen::{compute_score, Score};
+use crate::score_gen::Score;
 use anyhow::{Error, Result};
 use dusk_plonk::jubjub::{
     AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -28,7 +28,7 @@ pub struct Bid {
 }
 
 impl Bid {
-    pub fn init<R>(
+    pub fn new<R>(
         pk: AffinePoint,
         rng: &mut R,
         value: &JubJubScalar,

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -3,7 +3,6 @@
 //! Bid data structure
 
 use super::BidGenerationError;
-use crate::score_gen::Score;
 use anyhow::{Error, Result};
 use dusk_plonk::jubjub::{
     AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
@@ -16,16 +15,16 @@ use rand_core::{CryptoRng, RngCore};
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Bid {
     // b_enc (encrypted value and blinder)
-    pub(crate) encrypted_data: PoseidonCipher,
-    pub(crate) nonce: BlsScalar,
+    pub encrypted_data: PoseidonCipher,
+    pub nonce: BlsScalar,
     // R = r * G
-    pub(crate) randomness: AffinePoint,
+    pub randomness: AffinePoint,
     // m
-    pub(crate) hashed_secret: BlsScalar,
+    pub hashed_secret: BlsScalar,
     // pk (Public Key - Stealth Address) // XXX: Likely to become pk_r
-    pub(crate) pk: AffinePoint,
+    pub pk: AffinePoint,
     // c (Pedersen Commitment)
-    pub(crate) c: AffinePoint,
+    pub c: AffinePoint,
 }
 
 impl Bid {

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -126,7 +126,7 @@ mod tests {
             .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
 
-        Bid::init(
+        Bid::new(
             AffinePoint::from(secret),
             &mut rng,
             &value,

--- a/src/bid/mod.rs
+++ b/src/bid/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
 pub use bid::Bid;
-pub use encoding::StorageBid;
 use errors::BidGenerationError;
 pub(crate) mod bid;
 pub(crate) mod encoding;

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -2,7 +2,7 @@
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
 //! BlindBidProof module.
 
-use crate::bid::{Bid, StorageBid};
+use crate::bid::Bid;
 use crate::score_gen::*;
 use anyhow::Result;
 use dusk_plonk::constraint_system::ecc::scalar_mul::fixed_base::scalar_mul;
@@ -22,33 +22,49 @@ use poseidon252::{
 /// Generates the proof of BlindBid
 pub fn blind_bid_proof(
     composer: &mut StandardComposer,
-    bid: &Bid,
+    bid: Bid,
+    score: Score,
     branch: &PoseidonBranch,
     secret: &AffinePoint,
+    secret_k: BlsScalar,
+    latest_consensus_step: BlsScalar,
+    latest_consensus_round: BlsScalar,
+    seed: BlsScalar,
+    elegibility_ts: BlsScalar,
+    expiration_ts: BlsScalar,
 ) -> Result<()> {
     // Generate constant witness values for 0.
     let zero = composer.add_witness_to_circuit_description(BlsScalar::zero());
     // Get the corresponding `StorageBid` value that for the `Bid`
     // which is effectively the value of the proven leaf.
-    let storage_bid = StorageBid::from(bid);
-    let encoded_bid: StorageScalar = storage_bid.into();
+    let encoded_bid: StorageScalar = bid.into();
     let proven_leaf = composer.add_input(encoded_bid.into());
     // Allocate bid-needed inputs
+    let seed = AllocatedScalar::allocate(composer, seed);
     let latest_consensus_step =
-        AllocatedScalar::allocate(composer, bid.latest_consensus_step);
-    let elegibility_ts = AllocatedScalar::allocate(
-        composer,
-        BlsScalar::from(bid.elegibility_ts as u64),
+        AllocatedScalar::allocate(composer, latest_consensus_step);
+    let latest_consensus_round =
+        AllocatedScalar::allocate(composer, latest_consensus_round);
+    let elegibility_ts = AllocatedScalar::allocate(composer, elegibility_ts);
+    let expiration_ts = AllocatedScalar::allocate(composer, expiration_ts);
+    // Allocate the bid tree root to be used later by the score_generation
+    // gadget.
+    let bid_tree_root = AllocatedScalar::allocate(composer, branch.root);
+    // Constraint the bid_tree_root against a PI that represents
+    // the root of the Bid tree that lives inside of the `Bid` contract.
+    composer.constrain_to_constant(
+        bid_tree_root.var,
+        BlsScalar::zero(),
+        -branch.root,
     );
-    let expiration_ts = AllocatedScalar::allocate(
-        composer,
-        BlsScalar::from(bid.expiration_ts as u64),
-    );
+
+    // XXX: This should come from a decryption. See with Togh.
+    let secret_k = AllocatedScalar::allocate(composer, secret_k);
 
     // 1. Merkle Opening
     merkle_opening_gadget(composer, branch.clone(), proven_leaf, branch.root);
     // 2. Bid pre_image check
-    storage_bid.preimage_gadget(composer);
+    bid.preimage_gadget(composer);
     // 3. k_t <= t_a
     let third_cond = range_check(
         composer,
@@ -79,9 +95,9 @@ pub fn blind_bid_proof(
     let blinder = decrypted_data[1];
 
     // 5. c = C(v, b) Pedersen Commitment check
-    let bid_value = composer.add_input(value.into());
+    let bid_value = AllocatedScalar::allocate(composer, value.into());
     let blinder = composer.add_input(blinder.into());
-    let p1 = scalar_mul(composer, bid_value, GENERATOR_EXTENDED);
+    let p1 = scalar_mul(composer, bid_value.var, GENERATOR_EXTENDED);
     let p2 = scalar_mul(composer, blinder, GENERATOR_NUMS_EXTENDED);
     let computed_c = p1.point().fast_add(composer, *p2.point());
     // Assert computed_commitment == announced commitment.
@@ -95,159 +111,41 @@ pub fn blind_bid_proof(
     composer.range_gate(value, 64usize);
 
     // 7. `m = H(k)` Secret key pre-image check.
-    let secret_k = composer.add_input(bid.secret_k);
-    let secret_k_hash = sponge_hash_gadget(composer, &[secret_k]);
+    let secret_k_hash = sponge_hash_gadget(composer, &[secret_k.var]);
     // Constraint the secret_k_hash to be equal to the publicly avaliable one.
     composer.constrain_to_constant(
         secret_k_hash,
         BlsScalar::zero(),
-        -sponge_hash(&[bid.secret_k]),
+        -bid.hashed_secret,
     );
 
+    // XXX: Check this not used anywhere else.
     // 8. `prover_id = H(secret_k, sigma^s, k^t, k^s)`. Preimage check
-    let sigma_s = composer.add_input(bid.consensus_round_seed);
-    let k_t = composer.add_input(bid.latest_consensus_round);
-    let k_s = composer.add_input(bid.latest_consensus_step);
-    let prover_id =
-        sponge_hash_gadget(composer, &[secret_k, sigma_s, k_t, k_s]);
-    composer.constrain_to_constant(
+    let prover_id = sponge_hash_gadget(
+        composer,
+        &[
+            secret_k.var,
+            seed.var,
+            latest_consensus_round.var,
+            latest_consensus_step.var,
+        ],
+    );
+    // Seems that there's no need to constrain that, just compute the value which is never used later on.
+    /*composer.constrain_to_constant(
         prover_id,
         BlsScalar::zero(),
         -bid.prover_id,
-    );
+    );*/
     // 9. Score generation circuit check with the corresponding gadget.
-    prove_correct_score_gadget(composer, bid, value)?;
+    prove_correct_score_gadget(
+        composer,
+        score,
+        bid_value,
+        secret_k,
+        bid_tree_root,
+        seed,
+        latest_consensus_round,
+        latest_consensus_step,
+    )?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::bid::bid::tests::random_bid;
-    use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
-    use kelvin::Blake2b;
-    use poseidon252::PoseidonTree;
-
-    #[test]
-    fn correct_blindbid_proof() -> Result<()> {
-        // Generate Composer & Public Parameters
-        let pub_params =
-            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 16)?;
-
-        // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
-
-        // Generate a correct Bid
-        let secret = JubJubScalar::random(&mut rand::thread_rng());
-        let bid = random_bid(&secret);
-        let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
-
-        // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(StorageBid::from(&bid).into())?;
-
-        // Extract the branch
-        let branch = tree
-            .poseidon_branch(0u64)?
-            .expect("Poseidon Branch Extraction");
-
-        // Proving
-        let mut prover = Prover::new(b"testing");
-        blind_bid_proof(prover.mut_cs(), &bid, &branch, &secret)?;
-        //assert!(prover.mut_cs().circuit_size() == 49693);
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
-
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        blind_bid_proof(verifier.mut_cs(), &bid, &branch, &secret)?;
-        verifier.preprocess(&ck)?;
-
-        let pi = verifier.mut_cs().public_inputs.clone();
-        verifier.verify(&proof, &vk, &pi)?;
-        Ok(())
-    }
-
-    #[test]
-    fn edited_score_blindbid_proof() -> Result<()> {
-        // Generate Composer & Public Parameters
-        let pub_params =
-            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 16)?;
-
-        // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
-
-        // Generate a correct Bid
-        let secret = JubJubScalar::random(&mut rand::thread_rng());
-        let mut bid = random_bid(&secret);
-        let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
-
-        // Edit the Bid structure to cheat by incrementing the Score.
-        bid.score.score = -BlsScalar::one();
-        // Edit the Bid structure by editing the expiration_ts.
-        bid.expiration_ts = 13256586u32;
-        // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(StorageBid::from(&bid).into())?;
-
-        // Extract the branch
-        let branch = tree
-            .poseidon_branch(0u64)?
-            .expect("Poseidon Branch Extraction");
-
-        // Proving
-        let mut prover = Prover::new(b"testing");
-        blind_bid_proof(prover.mut_cs(), &bid, &branch, &secret)?;
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
-
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        blind_bid_proof(verifier.mut_cs(), &bid, &branch, &secret)?;
-        verifier.preprocess(&ck)?;
-        let pi = verifier.mut_cs().public_inputs.clone();
-        assert!(verifier.verify(&proof, &vk, &pi).is_err());
-        Ok(())
-    }
-
-    #[test]
-    fn edited_bid_value_blindbid_proof() -> Result<()> {
-        // Generate Composer & Public Parameters
-        let pub_params =
-            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
-        let (ck, vk) = pub_params.trim(1 << 16)?;
-
-        // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
-
-        // Generate a correct Bid
-        let secret = JubJubScalar::random(&mut rand::thread_rng());
-        let mut bid = random_bid(&secret);
-        let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
-
-        let value = crate::V_MAX + JubJubScalar::one();
-        bid.set_value(&mut rand::thread_rng(), &value, &secret);
-
-        // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(StorageBid::from(&bid).into())?;
-
-        // Extract the branch
-        let branch = tree
-            .poseidon_branch(0u64)?
-            .expect("Poseidon Branch Extraction");
-
-        // Proving
-        let mut prover = Prover::new(b"testing");
-        blind_bid_proof(prover.mut_cs(), &bid, &branch, &secret)?;
-        prover.preprocess(&ck)?;
-        let proof = prover.prove(&ck)?;
-
-        // Verification
-        let mut verifier = Verifier::new(b"testing");
-        blind_bid_proof(verifier.mut_cs(), &bid, &branch, &secret)?;
-        verifier.preprocess(&ck)?;
-        let pi = verifier.mut_cs().public_inputs.clone();
-        assert!(verifier.verify(&proof, &vk, &pi).is_err());
-        Ok(())
-    }
 }

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -4,8 +4,8 @@
 pub(crate) mod errors;
 pub mod score;
 use dusk_plonk::bls12_381::Scalar as BlsScalar;
+pub(crate) use score::prove_correct_score_gadget;
 pub use score::Score;
-pub(crate) use score::{compute_score, prove_correct_score_gadget};
 
 pub(crate) const SCALAR_FIELD_ORD_DIV_2_POW_128: BlsScalar =
     BlsScalar::from_raw([

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -279,7 +279,7 @@ mod tests {
             .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
 
-        Bid::init(
+        Bid::new(
             AffinePoint::from(secret),
             &mut rng,
             &value,

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -17,7 +17,7 @@ use poseidon252::sponge::*;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct Score {
-    pub(crate) score: BlsScalar,
+    pub score: BlsScalar,
     pub(crate) y: BlsScalar,
     pub(crate) y_prime: BlsScalar,
     pub(crate) r1: BlsScalar,
@@ -102,7 +102,6 @@ impl Bid {
 /// Prints the proving statements in the passed Constraint System.
 pub fn prove_correct_score_gadget(
     composer: &mut StandardComposer,
-    bid: Bid,
     score: Score,
     bid_value: AllocatedScalar,
     secret_k: AllocatedScalar,
@@ -342,7 +341,7 @@ mod tests {
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
-        let mut bid = random_bid(&secret)?;
+        let bid = random_bid(&secret)?;
         let secret = GENERATOR_EXTENDED * &secret;
         let (value, _) = bid.decrypt_data(&secret.into())?;
 
@@ -354,7 +353,7 @@ mod tests {
         let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
 
         // Edit score fields which should make the test fail
-        let mut score = bid.compute_score(
+        let score = bid.compute_score(
             &secret.into(),
             secret_k,
             bid_tree_root,
@@ -384,7 +383,6 @@ mod tests {
         );
         prove_correct_score_gadget(
             prover.mut_cs(),
-            bid,
             score,
             alloc_value,
             alloc_secret_k,
@@ -417,7 +415,6 @@ mod tests {
         );
         prove_correct_score_gadget(
             verifier.mut_cs(),
-            bid,
             score,
             alloc_value,
             alloc_secret_k,
@@ -425,7 +422,7 @@ mod tests {
             alloc_consensus_round_seed,
             alloc_latest_consensus_round,
             alloc_latest_consensus_step,
-        );
+        )?;
         verifier.preprocess(&ck)?;
         verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
     }
@@ -439,7 +436,7 @@ mod tests {
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
-        let mut bid = random_bid(&secret)?;
+        let bid = random_bid(&secret)?;
         let secret = GENERATOR_EXTENDED * &secret;
         let (value, _) = bid.decrypt_data(&secret.into())?;
 
@@ -483,7 +480,6 @@ mod tests {
         );
         prove_correct_score_gadget(
             prover.mut_cs(),
-            bid,
             score,
             alloc_value,
             alloc_secret_k,
@@ -516,7 +512,6 @@ mod tests {
         );
         prove_correct_score_gadget(
             verifier.mut_cs(),
-            bid,
             score,
             alloc_value,
             alloc_secret_k,
@@ -524,7 +519,7 @@ mod tests {
             alloc_consensus_round_seed,
             alloc_latest_consensus_round,
             alloc_latest_consensus_step,
-        );
+        )?;
         verifier.preprocess(&ck)?;
         assert!(verifier
             .verify(&proof, &vk, &vec![BlsScalar::zero()])

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -18,7 +18,7 @@ fn random_bid(
     let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
     let value = JubJubScalar::from(value);
 
-    Bid::init(
+    Bid::new(
         AffinePoint::from(secret),
         &mut rng,
         &value,

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -1,0 +1,286 @@
+use anyhow::{Error, Result};
+use blind_bid::bid::Bid;
+use blind_bid::proof::blind_bid_proof;
+use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
+use dusk_plonk::prelude::*;
+use rand::Rng;
+
+const V_RAW_MIN: u64 = 50_000u64;
+const V_RAW_MAX: u64 = 250_000u64;
+
+fn random_bid(
+    secret: &JubJubScalar,
+    secret_k: BlsScalar,
+) -> Result<Bid, Error> {
+    let mut rng = rand::thread_rng();
+
+    let secret = GENERATOR_EXTENDED * secret;
+    let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+    let value = JubJubScalar::from(value);
+
+    Bid::init(
+        AffinePoint::from(secret),
+        &mut rng,
+        &value,
+        &AffinePoint::from(secret),
+        secret_k,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kelvin::Blake2b;
+    use poseidon252::PoseidonTree;
+
+    #[test]
+    fn correct_blindbid_proof() -> Result<()> {
+        // Generate Composer & Public Parameters
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
+
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+
+        // Generate a correct Bid
+        let secret = JubJubScalar::random(&mut rand::thread_rng());
+        let secret_k = BlsScalar::random(&mut rand::thread_rng());
+        let bid = random_bid(&secret, secret_k)?;
+        let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
+        // Generate fields for the Bid & required by the compute_score
+        let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
+        let elegibility_ts = BlsScalar::random(&mut rand::thread_rng());
+        let expiration_ts = BlsScalar::random(&mut rand::thread_rng());
+
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(bid.into())?;
+
+        // Extract the branch
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
+
+        // Generate a `Score` for our Bid with the consensus parameters
+        let score = bid.compute_score(
+            &secret,
+            secret_k,
+            bid_tree_root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        )?;
+
+        // Proving
+        let mut prover = Prover::new(b"testing");
+        blind_bid_proof(
+            prover.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
+
+        // Verification
+        let mut verifier = Verifier::new(b"testing");
+        blind_bid_proof(
+            verifier.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+        verifier.preprocess(&ck)?;
+
+        let pi = verifier.mut_cs().public_inputs.clone();
+        verifier.verify(&proof, &vk, &pi)
+    }
+
+    #[test]
+    fn edited_score_blindbid_proof() -> Result<()> {
+        // Generate Composer & Public Parameters
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
+
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+
+        // Generate a correct Bid
+        let secret = JubJubScalar::random(&mut rand::thread_rng());
+        let secret_k = BlsScalar::random(&mut rand::thread_rng());
+        let bid = random_bid(&secret, secret_k)?;
+        let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
+        // Generate fields for the Bid & required by the compute_score
+        let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
+        let elegibility_ts = BlsScalar::random(&mut rand::thread_rng());
+        let expiration_ts = BlsScalar::random(&mut rand::thread_rng());
+
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(bid.into())?;
+
+        // Extract the branch
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
+
+        // Generate a `Score` for our Bid with the consensus parameters
+        let mut score = bid.compute_score(
+            &secret,
+            secret_k,
+            bid_tree_root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        )?;
+
+        // Edit the Score so that we try to get a bigger one than the one we should have got.
+        score.score = score.score + BlsScalar::from(100u64);
+
+        // Proving
+        let mut prover = Prover::new(b"testing");
+        blind_bid_proof(
+            prover.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
+
+        // Verification
+        let mut verifier = Verifier::new(b"testing");
+        blind_bid_proof(
+            verifier.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+        verifier.preprocess(&ck)?;
+
+        let pi = verifier.mut_cs().public_inputs.clone();
+        assert!(verifier.verify(&proof, &vk, &pi).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn edited_bid_value_blindbid_proof() -> Result<()> {
+        // Generate Composer & Public Parameters
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
+
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+
+        // Generate a correct Bid
+        let secret = JubJubScalar::random(&mut rand::thread_rng());
+        let secret_k = BlsScalar::random(&mut rand::thread_rng());
+        let mut bid = random_bid(&secret, secret_k)?;
+        let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
+        // Generate fields for the Bid & required by the compute_score
+        let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
+        let elegibility_ts = BlsScalar::random(&mut rand::thread_rng());
+        let expiration_ts = BlsScalar::random(&mut rand::thread_rng());
+
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(bid.into())?;
+
+        // Extract the branch
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
+
+        // Generate a `Score` for our Bid with the consensus parameters
+        let score = bid.compute_score(
+            &secret,
+            secret_k,
+            bid_tree_root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        )?;
+
+        // Edit the Bid in order to cheat and get a bigger Score/whatever.
+        bid.hashed_secret = BlsScalar::from(63463245u64);
+
+        // Proving
+        let mut prover = Prover::new(b"testing");
+        blind_bid_proof(
+            prover.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
+
+        // Verification
+        let mut verifier = Verifier::new(b"testing");
+        blind_bid_proof(
+            verifier.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+        verifier.preprocess(&ck)?;
+
+        let pi = verifier.mut_cs().public_inputs.clone();
+        assert!(verifier.verify(&proof, &vk, &pi).is_err());
+        Ok(())
+    }
+}


### PR DESCRIPTION
- There's only a single type for the Bid now
and all of the functions related to it's creation
or encoding have been refactored to work according to
that.

- Refactored also the tests of the score generation
to work with AllocatedScalar and left public only
a `gen_score` method implemented for the `Bid` data
structure.

- The blindbid gadget wasn't having the appropiate fn
signatures and wasn't using the single Bid structure
approach introduced on the previous commits.
Also, the tests weren't done as integration tests.

Therefore, the signature of the gadget fn has been refactored
to accept the consensus parameters and the score in order to
make the proof.
Also, we've moved the tests from the proof.rs file to the integration
tests folder.
Closes #56
Closes #51