### PR TITLE
Pki integration & Bid fields refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.0"
+dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", branch = "fix_err"}
 dusk-plonk = {version = "0.2.8", features = ["trace-print"]}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.2"}
 kelvin = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.0"
-dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", branch = "fix_err"}
+dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.1.1"}
 dusk-plonk = {version = "0.2.8", features = ["trace-print"]}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.2"}
 kelvin = "0.13.0"

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -143,8 +143,8 @@ mod tests {
         stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
         stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
         let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
-        let elegibility_ts = BlsScalar::random(&mut rng);
-        let expiration_ts = BlsScalar::random(&mut rng);
+        let elegibility_ts = -BlsScalar::one();
+        let expiration_ts = -BlsScalar::one();
 
         Bid::new(
             &mut rng,

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -120,7 +120,7 @@ impl Bid {
 mod tests {
     use super::*;
     use anyhow::{Error, Result};
-    use dusk_pki::StealthAddress;
+    use dusk_pki::{PublicSpendKey, SecretSpendKey, StealthAddress};
     use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
     use rand::Rng;
     use std::convert::TryFrom;
@@ -129,20 +129,13 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let secret_k = BlsScalar::random(&mut rng);
+        let pk_r = PublicSpendKey::from(SecretSpendKey::default());
+        let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())
             .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
-        let pk_r = AffinePoint::from(
-            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
-        );
-        let R = AffinePoint::from(
-            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
-        );
-        let mut stealth_addr_buff = [0u8; 64];
-        stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
-        stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
-        let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
+
         let elegibility_ts = -BlsScalar::one();
         let expiration_ts = -BlsScalar::one();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 // Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
 //! BlindBid impl
-
+#![allow(non_snake_case)]
 pub mod bid;
 pub mod proof;
 pub mod score_gen;

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -119,7 +119,8 @@ pub fn blind_bid_proof(
         -bid.hashed_secret,
     );
 
-    // XXX: Check this not used anywhere else.
+    // We generate the prover_id and constrain it to a public input
+    // On that way we bind the Score to the correct id.
     // 8. `prover_id = H(secret_k, sigma^s, k^t, k^s)`. Preimage check
     let prover_id = sponge_hash_gadget(
         composer,
@@ -131,11 +132,16 @@ pub fn blind_bid_proof(
         ],
     );
     // Seems that there's no need to constrain that, just compute the value which is never used later on.
-    /*composer.constrain_to_constant(
+    composer.constrain_to_constant(
         prover_id,
         BlsScalar::zero(),
-        -bid.prover_id,
-    );*/
+        -bid.generate_prover_id(
+            secret_k.scalar,
+            seed.scalar,
+            latest_consensus_round.scalar,
+            latest_consensus_step.scalar,
+        ),
+    );
     // 9. Score generation circuit check with the corresponding gadget.
     prove_correct_score_gadget(
         composer,

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -65,13 +65,18 @@ pub fn blind_bid_proof(
     merkle_opening_gadget(composer, branch.clone(), proven_leaf, branch.root);
     // 2. Bid pre_image check
     bid.preimage_gadget(composer);
-    // 3. k_t <= t_a
+    // 3. t_a >= k_t
     let third_cond = range_check(
         composer,
         latest_consensus_round.scalar,
         -BlsScalar::one(),
         elegibility_ts,
-    ); // XXX: Does t_a have a max?
+    ); // XXX: Check if we can use the formula below.
+    composer.constrain_to_constant(
+        third_cond,
+        BlsScalar::one(),
+        BlsScalar::zero(),
+    );
 
     // 4. t_e >= k_t
     let fourth_cond =
@@ -81,15 +86,9 @@ pub fn blind_bid_proof(
     let fourth_cond = conditionally_select_one(composer, zero, fourth_cond);
     // Constraint third and fourth conditions to be true.
     // So basically, that the rangeproofs hold.
-    composer.poly_gate(
-        third_cond,
+    composer.constrain_to_constant(
         fourth_cond,
-        zero,
         BlsScalar::one(),
-        BlsScalar::zero(),
-        BlsScalar::zero(),
-        BlsScalar::zero(),
-        BlsScalar::zero(),
         BlsScalar::zero(),
     );
 

--- a/src/score_gen/errors.rs
+++ b/src/score_gen/errors.rs
@@ -11,4 +11,8 @@ pub enum ScoreError {
     /// fit inside a `Scalar`.
     #[error("score results do not fit inside of Scalar")]
     InvalidScoreFieldsLen,
+    /// Error that happens when you try to generate a `Score` for a `Bid`
+    /// has already expired.
+    #[error("the bid has already expired")]
+    ExpiredBid,
 }

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -293,8 +293,8 @@ mod tests {
         stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
         stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
         let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
-        let elegibility_ts = BlsScalar::random(&mut rng);
-        let expiration_ts = BlsScalar::random(&mut rng);
+        let elegibility_ts = -BlsScalar::one();
+        let expiration_ts = -BlsScalar::one();
 
         Bid::new(
             &mut rng,
@@ -368,8 +368,10 @@ mod tests {
         let secret_k = BlsScalar::random(&mut rand::thread_rng());
         let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
         let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
+        // Set latest consensus round as the max value so the score gen does not fail
+        // for that but for the proof verification error if that's the case
         let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
-        let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_step = BlsScalar::from(2u64);
 
         // Edit score fields which should make the test fail
         let score = bid.compute_score(
@@ -463,8 +465,10 @@ mod tests {
         let secret_k = BlsScalar::random(&mut rand::thread_rng());
         let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
         let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
+        // Set the timestamps to the maximum possible value so the generation of the
+        // score does not fail for that reason but for the proof verification.
         let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
-        let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
+        let latest_consensus_step = BlsScalar::from(2u64);
 
         // Edit score fields which should make the test fail
         let mut score = bid.compute_score(

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -53,6 +53,9 @@ impl Bid {
         latest_consensus_round: BlsScalar,
         latest_consensus_step: BlsScalar,
     ) -> Result<Score, Error> {
+        if latest_consensus_round.reduce() > self.expiration_ts.reduce() {
+            return Err(ScoreError::ExpiredBid.into());
+        };
         // Compute `y` where `y = H(secret_k, Merkle_root, consensus_round_seed,
         // latest_consensus_round, latest_consensus_step)`.
         let y = sponge::sponge_hash(&[

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -270,29 +270,20 @@ fn biguint_to_scalar(biguint: BigUint) -> Result<BlsScalar, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dusk_pki::StealthAddress;
+    use dusk_pki::{PublicSpendKey, SecretSpendKey};
     use dusk_plonk::jubjub::GENERATOR_EXTENDED;
     use rand::Rng;
-    use std::convert::TryFrom;
 
     fn random_bid(secret: &JubJubScalar) -> Result<Bid, Error> {
         let mut rng = rand::thread_rng();
 
         let secret_k = BlsScalar::random(&mut rng);
+        let pk_r = PublicSpendKey::from(SecretSpendKey::default());
+        let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())
             .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
-        let pk_r = AffinePoint::from(
-            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
-        );
-        let R = AffinePoint::from(
-            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
-        );
-        let mut stealth_addr_buff = [0u8; 64];
-        stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
-        stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
-        let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
         let elegibility_ts = -BlsScalar::one();
         let expiration_ts = -BlsScalar::one();
 

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -69,8 +69,6 @@ mod tests {
         let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
-        let elegibility_ts = BlsScalar::random(&mut rand::thread_rng());
-        let expiration_ts = BlsScalar::random(&mut rand::thread_rng());
 
         // Append the StorageBid as an StorageScalar to the tree.
         tree.push(bid.into())?;
@@ -102,8 +100,6 @@ mod tests {
             latest_consensus_step,
             latest_consensus_round,
             consensus_round_seed,
-            elegibility_ts,
-            expiration_ts,
         )?;
 
         prover.preprocess(&ck)?;
@@ -121,8 +117,6 @@ mod tests {
             latest_consensus_step,
             latest_consensus_round,
             consensus_round_seed,
-            elegibility_ts,
-            expiration_ts,
         )?;
         verifier.preprocess(&ck)?;
 
@@ -150,8 +144,6 @@ mod tests {
         let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
-        let elegibility_ts = BlsScalar::random(&mut rand::thread_rng());
-        let expiration_ts = BlsScalar::random(&mut rand::thread_rng());
 
         // Append the StorageBid as an StorageScalar to the tree.
         tree.push(bid.into())?;
@@ -186,8 +178,6 @@ mod tests {
             latest_consensus_step,
             latest_consensus_round,
             consensus_round_seed,
-            elegibility_ts,
-            expiration_ts,
         )?;
 
         prover.preprocess(&ck)?;
@@ -205,8 +195,6 @@ mod tests {
             latest_consensus_step,
             latest_consensus_round,
             consensus_round_seed,
-            elegibility_ts,
-            expiration_ts,
         )?;
         verifier.preprocess(&ck)?;
 
@@ -235,8 +223,6 @@ mod tests {
         let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
-        let elegibility_ts = BlsScalar::random(&mut rand::thread_rng());
-        let expiration_ts = BlsScalar::random(&mut rand::thread_rng());
 
         // Append the StorageBid as an StorageScalar to the tree.
         tree.push(bid.into())?;
@@ -271,8 +257,6 @@ mod tests {
             latest_consensus_step,
             latest_consensus_round,
             consensus_round_seed,
-            elegibility_ts,
-            expiration_ts,
         )?;
 
         prover.preprocess(&ck)?;
@@ -290,12 +274,113 @@ mod tests {
             latest_consensus_step,
             latest_consensus_round,
             consensus_round_seed,
-            elegibility_ts,
-            expiration_ts,
         )?;
         verifier.preprocess(&ck)?;
 
         let pi = verifier.mut_cs().public_inputs.clone();
+        assert!(verifier.verify(&proof, &vk, &pi).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn expired_bid_proof() -> Result<()> {
+        // Generate Composer & Public Parameters
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
+
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+
+        // Create an expired bid.
+        let mut rng = rand::thread_rng();
+        let secret = AffinePoint::from(
+            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
+        );
+        let secret_k = BlsScalar::random(&mut rng);
+        let value: u64 = (&mut rand::thread_rng())
+            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+        let value = JubJubScalar::from(value);
+        let pk_r = AffinePoint::from(
+            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
+        );
+        let R = AffinePoint::from(
+            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
+        );
+        let mut stealth_addr_buff = [0u8; 64];
+        stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
+        stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
+        let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
+        let expiration_ts = BlsScalar::from(95u64);
+        let elegibility_ts = BlsScalar::from(1000u64);
+        let bid = Bid::new(
+            &mut rng,
+            &stealth_addr,
+            &value,
+            &secret.into(),
+            secret_k,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(bid.into())?;
+
+        // Extract the branch
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
+
+        // Latest consensus step should be lower than the expiration_ts, in this case is not
+        // so the proof should fail sincethe Bid expired.
+        let latest_consensus_round = BlsScalar::from(90u64);
+        let latest_consensus_step = BlsScalar::one();
+        let consensus_round_seed = BlsScalar::random(&mut rng);
+
+        // Generate a `Score` for our Bid with the consensus parameters
+        let score = bid.compute_score(
+            &secret,
+            secret_k,
+            branch.root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        )?;
+
+        // Proving
+        let mut prover = Prover::new(b"testing");
+        blind_bid_proof(
+            prover.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+        )?;
+
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
+
+        // Verification
+        let mut verifier = Verifier::new(b"testing");
+        blind_bid_proof(
+            verifier.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+        )?;
+        verifier.preprocess(&ck)?;
+
+        let pi = verifier.mut_cs().public_inputs.clone();
+        // The proof should fail since it is expired.
         assert!(verifier.verify(&proof, &vk, &pi).is_err());
         Ok(())
     }

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -1,9 +1,12 @@
+#![allow(non_snake_case)]
 use anyhow::{Error, Result};
 use blind_bid::bid::Bid;
 use blind_bid::proof::blind_bid_proof;
+use dusk_pki::StealthAddress;
 use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
 use dusk_plonk::prelude::*;
 use rand::Rng;
+use std::convert::TryFrom;
 
 const V_RAW_MIN: u64 = 50_000u64;
 const V_RAW_MAX: u64 = 250_000u64;
@@ -15,15 +18,28 @@ fn random_bid(
     let mut rng = rand::thread_rng();
 
     let secret = GENERATOR_EXTENDED * secret;
-    let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+    let value: u64 =
+        (&mut rand::thread_rng()).gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
     let value = JubJubScalar::from(value);
+    let pk_r =
+        AffinePoint::from(GENERATOR_EXTENDED * JubJubScalar::random(&mut rng));
+    let R =
+        AffinePoint::from(GENERATOR_EXTENDED * JubJubScalar::random(&mut rng));
+    let mut stealth_addr_buff = [0u8; 64];
+    stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
+    stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
+    let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
+    let elegibility_ts = BlsScalar::random(&mut rng);
+    let expiration_ts = BlsScalar::random(&mut rng);
 
     Bid::new(
-        AffinePoint::from(secret),
         &mut rng,
+        &stealth_addr,
         &value,
-        &AffinePoint::from(secret),
+        &secret.into(),
         secret_k,
+        elegibility_ts,
+        expiration_ts,
     )
 }
 

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -29,8 +29,10 @@ fn random_bid(
     stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
     stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
     let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
-    let elegibility_ts = BlsScalar::random(&mut rng);
-    let expiration_ts = BlsScalar::random(&mut rng);
+    // Set the timestamps as the max values so the proofs do not fail for them
+    // (never expired or non-elegible).
+    let elegibility_ts = -BlsScalar::one();
+    let expiration_ts = -BlsScalar::one();
 
     Bid::new(
         &mut rng,
@@ -381,6 +383,109 @@ mod tests {
 
         let pi = verifier.mut_cs().public_inputs.clone();
         // The proof should fail since it is expired.
+        assert!(verifier.verify(&proof, &vk, &pi).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn non_elegible_bid() -> Result<()> {
+        // Generate Composer & Public Parameters
+        let pub_params =
+            PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
+        let (ck, vk) = pub_params.trim(1 << 16)?;
+
+        // Generate a PoseidonTree and append the Bid.
+        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+
+        // Create a non-elegible Bid.
+        let mut rng = rand::thread_rng();
+        let secret = AffinePoint::from(
+            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
+        );
+        let secret_k = BlsScalar::random(&mut rng);
+        let value: u64 = (&mut rand::thread_rng())
+            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+        let value = JubJubScalar::from(value);
+        let pk_r = AffinePoint::from(
+            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
+        );
+        let R = AffinePoint::from(
+            GENERATOR_EXTENDED * JubJubScalar::random(&mut rng),
+        );
+        let mut stealth_addr_buff = [0u8; 64];
+        stealth_addr_buff[0..32].copy_from_slice(&pk_r.to_bytes()[..]);
+        stealth_addr_buff[32..].copy_from_slice(&R.to_bytes()[..]);
+        let stealth_addr = StealthAddress::try_from(&stealth_addr_buff)?;
+        let expiration_ts = BlsScalar::from(120u64);
+        let elegibility_ts = BlsScalar::from(1000u64);
+        let bid = Bid::new(
+            &mut rng,
+            &stealth_addr,
+            &value,
+            &secret.into(),
+            secret_k,
+            elegibility_ts,
+            expiration_ts,
+        )?;
+
+        // Append the StorageBid as an StorageScalar to the tree.
+        tree.push(bid.into())?;
+
+        // Extract the branch
+        let branch = tree
+            .poseidon_branch(0u64)?
+            .expect("Poseidon Branch Extraction");
+
+        // Latest consensus step should be lower than the elegibility_ts, in this case is not
+        // so the proof should fail since the Bid is non elegible anymore.
+        let latest_consensus_round = BlsScalar::from(90u64);
+        let latest_consensus_step = BlsScalar::one();
+        let consensus_round_seed = BlsScalar::random(&mut rng);
+
+        // Generate a `Score` for our Bid with the consensus parameters
+        let score = bid.compute_score(
+            &secret,
+            secret_k,
+            branch.root,
+            consensus_round_seed,
+            latest_consensus_round,
+            latest_consensus_step,
+        )?;
+
+        // Proving
+        let mut prover = Prover::new(b"testing");
+        blind_bid_proof(
+            prover.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+        )?;
+
+        prover.preprocess(&ck)?;
+        let proof = prover.prove(&ck)?;
+
+        // Verification
+        let mut verifier = Verifier::new(b"testing");
+        blind_bid_proof(
+            verifier.mut_cs(),
+            bid,
+            score,
+            &branch,
+            &secret,
+            secret_k,
+            latest_consensus_step,
+            latest_consensus_round,
+            consensus_round_seed,
+        )?;
+        verifier.preprocess(&ck)?;
+
+        let pi = verifier.mut_cs().public_inputs.clone();
+        // The proof should fail since it is non elegible.
         assert!(verifier.verify(&proof, &vk, &pi).is_err());
         Ok(())
     }


### PR DESCRIPTION
- We were missing the `StealthAddr` type in the `Bid` struct
which is what allows us to know if we're the owner.
Added the `StealthAddr` to the `Bid` and refactored it's
associated methods.

- We were not checking correctly that the conditions
were being satisfied.
It has been actually fixed and now we correctly check the
ranges of the timestamps stored in the bid against the
latest consensus round.

Added tests for non elegible & expired Bid testcases

Closes #48