### PR TITLE
Implement Kelvin + Read/Write =To/From bytes traits & fns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 anyhow = "1.0.0"
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.1.1"}
 dusk-plonk = {version = "0.2.8", features = ["trace-print"]}
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.2"}
-kelvin = "0.13.0"
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.4"}
+kelvin = "0.19.0"
 num-bigint = "0.2.6"
 num-traits = "0.2.11"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.2.0"}

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -17,6 +17,9 @@ use rand_core::{CryptoRng, RngCore};
 use std::convert::TryFrom;
 use std::io::{self, Read, Write};
 
+/// Size of a serialized Bid.
+/// The size is computed by adding up the `PoseidonCipher` size +
+/// `StealthAddress` size + 1 `AffinePoint` + 4 `BlsScalar`s.
 pub const BID_SIZE: usize = ENCRYPTED_DATA_SIZE + 64 + 32 * 5;
 
 #[derive(Copy, Clone, Debug)]

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -172,7 +172,7 @@ impl Bid {
         buf[192..224].copy_from_slice(&self.hashed_secret.to_bytes());
         buf[224..256].copy_from_slice(&self.c.to_bytes());
         buf[256..288].copy_from_slice(&self.elegibility_ts.to_bytes());
-        buf[288..310].copy_from_slice(&self.expiration_ts.to_bytes());
+        buf[288..320].copy_from_slice(&self.expiration_ts.to_bytes());
         buf
     }
 
@@ -181,7 +181,7 @@ impl Bid {
     // see issue #57563 <https://github.com/rust-lang/rust/issues/57563>
     /// Given the byte-representation of a `Bid`, generate one instance of it.
     pub fn from_bytes(bytes: [u8; BID_SIZE]) -> io::Result<Bid> {
-        let mut one_cipher = [0u8; 96];
+        let mut one_cipher = [0u8; ENCRYPTED_DATA_SIZE];
         let mut one_scalar = [0u8; 32];
         let mut one_stealth_address = [0u8; 64];
 
@@ -206,7 +206,7 @@ impl Bid {
         one_scalar[..].copy_from_slice(&bytes[256..288]);
         let elegibility_ts = read_scalar(&one_scalar)?;
 
-        one_scalar[..].copy_from_slice(&bytes[288..310]);
+        one_scalar[..].copy_from_slice(&bytes[288..320]);
         let expiration_ts = read_scalar(&one_scalar)?;
 
         Ok(Bid {

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -9,9 +9,15 @@ use dusk_plonk::jubjub::{
     AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
 };
 use dusk_plonk::prelude::*;
+use kelvin::{ByteHash, Content, Sink, Source};
 use poseidon252::cipher::PoseidonCipher;
+use poseidon252::cipher::ENCRYPTED_DATA_SIZE;
 use poseidon252::sponge::sponge::sponge_hash;
 use rand_core::{CryptoRng, RngCore};
+use std::convert::TryFrom;
+use std::io::{self, Read, Write};
+
+pub const BID_SIZE: usize = ENCRYPTED_DATA_SIZE + 64 + 32 * 5;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Bid {
@@ -153,12 +159,202 @@ impl Bid {
             .map_err(|_| Error::new(BidGenerationError::WrongSecretProvided))
     }
 
-    pub fn prove_score_generation(
-        &self,
-        _composer: &mut StandardComposer,
-    ) -> Result<Proof, Error> {
-        //use crate::score_gen::score::prove_correct_score_gadget;
+    // We cannot make this fn const since we need a mut buffer.
+    // mutable references in const fn are unstable
+    // see issue #57563 <https://github.com/rust-lang/rust/issues/57563>
+    /// Given a Bid, return the byte-representation of it.
+    pub fn to_bytes(&self) -> [u8; BID_SIZE] {
+        let mut buf = [0u8; BID_SIZE];
+        buf[0..ENCRYPTED_DATA_SIZE]
+            .copy_from_slice(&self.encrypted_data.to_bytes());
+        buf[ENCRYPTED_DATA_SIZE..128].copy_from_slice(&self.nonce.to_bytes());
+        buf[128..192].copy_from_slice(&self.stealth_address.to_bytes());
+        buf[192..224].copy_from_slice(&self.hashed_secret.to_bytes());
+        buf[224..256].copy_from_slice(&self.c.to_bytes());
+        buf[256..288].copy_from_slice(&self.elegibility_ts.to_bytes());
+        buf[288..310].copy_from_slice(&self.expiration_ts.to_bytes());
+        buf
+    }
 
-        unimplemented!()
+    // We cannot make this fn const since we need a mut buffer.
+    // mutable references in const fn are unstable
+    // see issue #57563 <https://github.com/rust-lang/rust/issues/57563>
+    /// Given the byte-representation of a `Bid`, generate one instance of it.
+    pub fn from_bytes(bytes: [u8; BID_SIZE]) -> io::Result<Bid> {
+        let mut one_cipher = [0u8; 96];
+        let mut one_scalar = [0u8; 32];
+        let mut one_stealth_address = [0u8; 64];
+
+        one_cipher[..].copy_from_slice(&bytes[0..ENCRYPTED_DATA_SIZE]);
+        let encrypted_data =
+            PoseidonCipher::from_bytes(&one_cipher).ok_or(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Could not recover PoseidonCipher from bytes"),
+            ))?;
+        one_scalar[..].copy_from_slice(&bytes[ENCRYPTED_DATA_SIZE..128]);
+        let nonce = read_scalar(&one_scalar)?;
+
+        one_stealth_address[..].copy_from_slice(&bytes[128..192]);
+        let stealth_address = StealthAddress::from_bytes(&one_stealth_address)?;
+
+        one_scalar[..].copy_from_slice(&bytes[192..224]);
+        let hashed_secret = read_scalar(&one_scalar)?;
+
+        one_scalar[..].copy_from_slice(&bytes[224..256]);
+        let c = read_jubjub_affine(&one_scalar)?;
+
+        one_scalar[..].copy_from_slice(&bytes[256..288]);
+        let elegibility_ts = read_scalar(&one_scalar)?;
+
+        one_scalar[..].copy_from_slice(&bytes[288..310]);
+        let expiration_ts = read_scalar(&one_scalar)?;
+
+        Ok(Bid {
+            encrypted_data,
+            nonce,
+            stealth_address,
+            hashed_secret,
+            c,
+            elegibility_ts,
+            expiration_ts,
+        })
+    }
+}
+
+impl Read for Bid {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut buf = io::BufWriter::new(&mut buf[..]);
+        let mut n = 0;
+
+        n += buf.write(&self.encrypted_data.to_bytes())?;
+        n += buf.write(&self.nonce.to_bytes())?;
+        n += buf.write(&self.stealth_address.to_bytes())?;
+        n += buf.write(&self.hashed_secret.to_bytes())?;
+        n += buf.write(&self.c.to_bytes())?;
+        n += buf.write(&self.elegibility_ts.to_bytes())?;
+        n += buf.write(&self.expiration_ts.to_bytes())?;
+
+        buf.flush()?;
+        Ok(n)
+    }
+}
+
+fn read_scalar(one_scalar: &[u8; 32]) -> io::Result<BlsScalar> {
+    let possible_scalar = BlsScalar::from_bytes(&one_scalar);
+    if possible_scalar.is_none().into() {
+        return Err(io::ErrorKind::InvalidData)?;
+    };
+    Ok(possible_scalar.unwrap())
+}
+
+fn read_jubjub_affine(one_point: &[u8; 32]) -> io::Result<AffinePoint> {
+    let possible_scalar = AffinePoint::from_bytes(*one_point);
+    if possible_scalar.is_none().into() {
+        return Err(io::ErrorKind::InvalidData)?;
+    };
+    Ok(possible_scalar.unwrap())
+}
+
+impl Write for Bid {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut buf = io::BufReader::new(&buf[..]);
+
+        let mut one_cipher = [0u8; 96];
+        let mut one_scalar = [0u8; 32];
+        let mut one_stealth_address = [0u8; 64];
+
+        let mut n = 0;
+
+        buf.read_exact(&mut one_cipher)?;
+        n += one_cipher.len();
+        self.encrypted_data =
+            PoseidonCipher::from_bytes(&one_cipher).ok_or(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Could not recover PoseidonCipher from bytes"),
+            ))?;
+
+        buf.read_exact(&mut one_scalar)?;
+        n += one_scalar.len();
+        self.nonce = read_scalar(&one_scalar)?;
+
+        buf.read_exact(&mut one_stealth_address)?;
+        n += one_stealth_address.len();
+        self.stealth_address =
+            StealthAddress::from_bytes(&one_stealth_address)?;
+
+        buf.read_exact(&mut one_scalar)?;
+        n += one_scalar.len();
+        self.hashed_secret = read_scalar(&one_scalar)?;
+
+        buf.read_exact(&mut one_scalar)?;
+        n += one_scalar.len();
+        self.c = read_jubjub_affine(&one_scalar)?;
+
+        buf.read_exact(&mut one_scalar)?;
+        n += one_scalar.len();
+        self.elegibility_ts = read_scalar(&one_scalar)?;
+
+        buf.read_exact(&mut one_scalar)?;
+        n += one_scalar.len();
+        self.expiration_ts = read_scalar(&one_scalar)?;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<H: ByteHash> Content<H> for Bid {
+    fn persist(&mut self, sink: &mut Sink<H>) -> io::Result<()> {
+        sink.write_all(&self.encrypted_data.to_bytes())?;
+        sink.write_all(&self.nonce.to_bytes())?;
+        sink.write_all(&self.stealth_address.to_bytes())?;
+        sink.write_all(&self.hashed_secret.to_bytes())?;
+        sink.write_all(&self.c.to_bytes())?;
+        sink.write_all(&self.elegibility_ts.to_bytes())?;
+        sink.write_all(&self.expiration_ts.to_bytes())?;
+        Ok(())
+    }
+
+    fn restore(source: &mut Source<H>) -> io::Result<Self> {
+        let mut one_scalar = [0u8; 32];
+        let mut one_stealth_address = [0u8; 64];
+
+        let mut encrypted_data_cipher = [0u8; ENCRYPTED_DATA_SIZE];
+        source.read_exact(&mut encrypted_data_cipher)?;
+        let encrypted_data = PoseidonCipher::from_bytes(&encrypted_data_cipher)
+            .ok_or(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Could not recover PoseidonCipher from bytes"),
+            ))?;
+
+        source.read_exact(&mut one_scalar)?;
+        let nonce = read_scalar(&one_scalar)?;
+
+        source.read_exact(&mut one_stealth_address)?;
+        let stealth_address = StealthAddress::try_from(&one_stealth_address)?;
+
+        source.read_exact(&mut one_scalar)?;
+        let hashed_secret = read_scalar(&one_scalar)?;
+
+        source.read_exact(&mut one_scalar)?;
+        let commitment = read_jubjub_affine(&one_scalar)?;
+
+        source.read_exact(&mut one_scalar)?;
+        let elegibility_ts = read_scalar(&one_scalar)?;
+
+        source.read_exact(&mut one_scalar)?;
+        let expiration_ts = read_scalar(&one_scalar)?;
+
+        Ok(Bid {
+            encrypted_data,
+            nonce,
+            stealth_address,
+            hashed_secret,
+            c: commitment,
+            elegibility_ts,
+            expiration_ts,
+        })
     }
 }

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -120,10 +120,9 @@ impl Bid {
 mod tests {
     use super::*;
     use anyhow::{Error, Result};
-    use dusk_pki::{PublicSpendKey, SecretSpendKey, StealthAddress};
-    use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
+    use dusk_pki::{PublicSpendKey, SecretSpendKey};
+    use dusk_plonk::jubjub::GENERATOR_EXTENDED;
     use rand::Rng;
-    use std::convert::TryFrom;
 
     fn random_bid(secret: &JubJubScalar) -> Result<Bid, Error> {
         let mut rng = rand::thread_rng();

--- a/src/bid/errors.rs
+++ b/src/bid/errors.rs
@@ -4,7 +4,6 @@
 
 use dusk_plonk::prelude::*;
 use thiserror::Error;
-
 /// Definition of the erros that Bid operations might have.
 #[derive(Error, Debug)]
 pub enum BidGenerationError<'a> {

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -11,8 +11,7 @@ use dusk_plonk::jubjub::{
 };
 use dusk_plonk::prelude::*;
 use plonk_gadgets::{
-    AllocatedScalar,
-    RangeGadgets::{max_bound, range_check},
+    AllocatedScalar, RangeGadgets::max_bound,
     ScalarGadgets::conditionally_select_one,
 };
 use poseidon252::{

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -38,7 +38,7 @@ fn random_bid(
 }
 
 #[cfg(test)]
-mod tests {
+mod protocol_tests {
     use super::*;
     use kelvin::Blake2b;
     use poseidon252::PoseidonTree;
@@ -466,6 +466,23 @@ mod tests {
         let pi = verifier.mut_cs().public_inputs.clone();
         // The proof should fail since it is non elegible.
         assert!(verifier.verify(&proof, &vk, &pi).is_err());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod serialization_tests {
+    use super::*;
+    use poseidon252::StorageScalar;
+
+    #[test]
+    fn from_to_bytes_impl_works() -> Result<()> {
+        let bid = random_bid(&JubJubScalar::one(), BlsScalar::one())?;
+        let bid_hash: StorageScalar = bid.into();
+        let bytes = bid.to_bytes();
+        let bid2 = Bid::from_bytes(bytes)?;
+        let bid_hash_2: StorageScalar = bid2.into();
+        assert_eq!(bid_hash.0, bid_hash_2.0);
         Ok(())
     }
 }

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -2,7 +2,6 @@
 use anyhow::{Error, Result};
 use blind_bid::bid::Bid;
 use blind_bid::proof::blind_bid_proof;
-use dusk_pki::StealthAddress;
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
 use dusk_plonk::prelude::*;


### PR DESCRIPTION
We were missing all of the Read/Write implementations
needed by the `Bid` structure.

This essentially implements all of the possible variants needed
by the libraries that use the blindbid as a dependency.

Closes #60 