### PR TITLE
Make PoseidonTree<Bid, Blake2b> possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 anyhow = "1.0.0"
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.1.1"}
 dusk-plonk = {version = "0.2.9", features = ["trace-print"]}
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.4"}
-kelvin = "0.18.0"
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.7.0"}
+kelvin = "0.19.0"
 num-bigint = "0.2.6"
 num-traits = "0.2.11"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.2.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.0"
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.1.1"}
 dusk-plonk = {version = "0.2.9", features = ["trace-print"]}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.4"}
-kelvin = "0.19.0"
+kelvin = "0.18.0"
 num-bigint = "0.2.6"
 num-traits = "0.2.11"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.2.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.0"
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.1.1"}
-dusk-plonk = {version = "0.2.8", features = ["trace-print"]}
+dusk-plonk = {version = "0.2.9", features = ["trace-print"]}
 poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.4"}
 kelvin = "0.19.0"
 num-bigint = "0.2.6"
@@ -16,6 +16,8 @@ num-traits = "0.2.11"
 plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.2.0"}
 thiserror = "1.0.20"
 rand_core = "0.5.1"
-
-[dev-dependencies]
+lazy_static = "1.4.0"
 rand = "0.7"
+
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,3 @@ thiserror = "1.0.20"
 rand_core = "0.5.1"
 lazy_static = "1.4.0"
 rand = "0.7"
-
-
-

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -124,7 +124,7 @@ impl Bid {
     ///
     /// The function performs the sponge_hash techniqe using poseidon to
     /// get the one-time prover_id and sets it in the Bid.
-    pub(crate) fn generate_prover_id(
+    pub fn generate_prover_id(
         &self,
         secret_k: BlsScalar,
         consensus_round_seed: BlsScalar,

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -79,6 +79,9 @@ impl From<Bid> for StorageScalar {
 /// Variable which contains the hash of the Bid.
 pub(crate) fn preimage_gadget(
     composer: &mut StandardComposer,
+    // TODO: We should switch to a different representation for this.
+    // it can be a custom PoseidonCipherVariable structure or maybe
+    // just a fixed len array of Variables.
     encrypted_data: (Variable, Variable),
     commitment: PlonkPoint,
     // (Pkr, R)

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -7,7 +7,6 @@
 
 use super::Bid;
 use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
-use dusk_plonk::jubjub::AffinePoint as JubJubAffine;
 use dusk_plonk::prelude::*;
 use poseidon252::{sponge::sponge::*, StorageScalar};
 
@@ -44,14 +43,14 @@ impl Into<StorageScalar> for &Bid {
         words_deposit.push(self.encrypted_data.cipher()[1]);
 
         // Push both JubJubAffine coordinates as a Scalar.
-        words_deposit.push(self.stealth_address.pk_r().get_x());
-        words_deposit.push(self.stealth_address.pk_r().get_y());
+        words_deposit.extend_from_slice(
+            self.stealth_address.pk_r().to_hash_inputs().as_ref(),
+        );
 
         // Push both JubJubAffine coordinates as a Scalar.
-        words_deposit
-            .push(JubJubAffine::from(self.stealth_address.R()).get_x());
-        words_deposit
-            .push(JubJubAffine::from(self.stealth_address.R()).get_y());
+        words_deposit.extend_from_slice(
+            self.stealth_address.R().to_hash_inputs().as_ref(),
+        );
 
         words_deposit.push(self.hashed_secret);
 

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -106,7 +106,8 @@ pub fn blind_bid_proof(
 
     // 3. t_a >= k_t
     let third_cond =
-        max_bound(composer, latest_consensus_round.scalar, elegibility_ts).0;
+        max_bound(composer, latest_consensus_round.scalar, bid_elegibility_ts)
+            .0;
     // We should get a 0 if t_e is greater, but we need this to be one in order
     // to hold. Therefore we conditionally select one.
     let third_cond = conditionally_select_one(composer, zero, third_cond);
@@ -120,7 +121,7 @@ pub fn blind_bid_proof(
 
     // 4. t_e >= k_t
     let fourth_cond =
-        max_bound(composer, latest_consensus_round.scalar, expiration_ts).0;
+        max_bound(composer, latest_consensus_round.scalar, bid_expiration_ts).0;
     // We should get a 0 if t_e is greater, but we need this to be one in order
     // to hold. Therefore we conditionally select one.
     let fourth_cond = conditionally_select_one(composer, zero, fourth_cond);

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -64,9 +64,6 @@ pub fn blind_bid_proof(
         AllocatedScalar::allocate(composer, latest_consensus_step);
     let latest_consensus_round =
         AllocatedScalar::allocate(composer, latest_consensus_round);
-    let elegibility_ts =
-        AllocatedScalar::allocate(composer, bid.elegibility_ts);
-    let expiration_ts = AllocatedScalar::allocate(composer, bid.expiration_ts);
     // Decrypt the cypher using the secret and allocate value & blinder
     let decrypted_data = bid.encrypted_data.decrypt(secret, &bid.nonce)?;
     let bid_value = AllocatedScalar::allocate(composer, decrypted_data[0]);

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,5 +1,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
-// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.”
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for
+// details.”
 //! BlindBidProof module.
 
 use crate::bid::Bid;
@@ -10,14 +11,16 @@ use dusk_plonk::jubjub::{
     AffinePoint, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
 };
 use dusk_plonk::prelude::*;
+use kelvin::Blake2b;
 use plonk_gadgets::{
     AllocatedScalar, RangeGadgets::max_bound,
     ScalarGadgets::conditionally_select_one,
 };
 use poseidon252::{
     merkle_proof::merkle_opening_gadget, sponge::sponge::*, PoseidonBranch,
-    StorageScalar,
+    PoseidonTree, StorageScalar,
 };
+use rand::{thread_rng, Rng};
 
 /// Generates the proof of BlindBid
 pub fn blind_bid_proof(
@@ -68,8 +71,8 @@ pub fn blind_bid_proof(
     // 3. t_a >= k_t
     let third_cond =
         max_bound(composer, latest_consensus_round.scalar, elegibility_ts).0;
-    // We should get a 0 if t_e is greater, but we need this to be one in order to hold.
-    // Therefore we conditionally select one.
+    // We should get a 0 if t_e is greater, but we need this to be one in order
+    // to hold. Therefore we conditionally select one.
     let third_cond = conditionally_select_one(composer, zero, third_cond);
     // Constraint third condition to be true.
     // So basically, that the rangeproofs hold.
@@ -82,8 +85,8 @@ pub fn blind_bid_proof(
     // 4. t_e >= k_t
     let fourth_cond =
         max_bound(composer, latest_consensus_round.scalar, expiration_ts).0;
-    // We should get a 0 if t_e is greater, but we need this to be one in order to hold.
-    // Therefore we conditionally select one.
+    // We should get a 0 if t_e is greater, but we need this to be one in order
+    // to hold. Therefore we conditionally select one.
     let fourth_cond = conditionally_select_one(composer, zero, fourth_cond);
     // Constraint fourth condition to be true.
     // So basically, that the rangeproofs hold.

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -39,8 +39,8 @@ pub fn blind_bid_proof(
     // Get the corresponding `StorageBid` value that for the `Bid`
     // which is effectively the value of the proven leaf (hash of the Bid)
     // and allocate it.
-    let bid_hash: StorageScalar = bid.into();
-    let bid_hash = AllocatedScalar::allocate(composer, bid_hash.0);
+    let bid_hash =
+        AllocatedScalar::allocate(composer, StorageScalar::from(bid).0);
     // Allocate Bid-internal fields
     let bid_hashed_secret =
         AllocatedScalar::allocate(composer, bid.hashed_secret);

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -51,7 +51,7 @@ mod protocol_tests {
         let (ck, vk) = pub_params.trim(1 << 16)?;
 
         // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<Bid, _> = PoseidonTree::new(17usize);
+        let mut tree: PoseidonTree<Bid, Blake2b> = PoseidonTree::new(17usize);
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -64,7 +64,7 @@ mod protocol_tests {
         let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
 
         // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(bid.into())?;
+        tree.push(bid)?;
 
         // Extract the branch
         let branch = tree
@@ -129,7 +129,7 @@ mod protocol_tests {
         let (ck, vk) = pub_params.trim(1 << 16)?;
 
         // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+        let mut tree: PoseidonTree<Bid, Blake2b> = PoseidonTree::new(17usize);
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -142,7 +142,7 @@ mod protocol_tests {
         let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
 
         // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(bid.into())?;
+        tree.push(bid)?;
 
         // Extract the branch
         let branch = tree
@@ -208,7 +208,7 @@ mod protocol_tests {
         let (ck, vk) = pub_params.trim(1 << 16)?;
 
         // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+        let mut tree: PoseidonTree<Bid, Blake2b> = PoseidonTree::new(17usize);
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -222,7 +222,7 @@ mod protocol_tests {
         let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
 
         // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(bid.into())?;
+        tree.push(bid)?;
 
         // Extract the branch
         let branch = tree
@@ -287,7 +287,7 @@ mod protocol_tests {
         let (ck, vk) = pub_params.trim(1 << 16)?;
 
         // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+        let mut tree: PoseidonTree<Bid, Blake2b> = PoseidonTree::new(17usize);
 
         // Create an expired bid.
         let mut rng = rand::thread_rng();
@@ -312,7 +312,7 @@ mod protocol_tests {
         )?;
 
         // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(bid.into())?;
+        tree.push(bid)?;
 
         // Extract the branch
         let branch = tree
@@ -385,7 +385,7 @@ mod protocol_tests {
         let (ck, vk) = pub_params.trim(1 << 16)?;
 
         // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+        let mut tree: PoseidonTree<Bid, Blake2b> = PoseidonTree::new(17usize);
 
         // Create a non-elegible Bid.
         let mut rng = rand::thread_rng();
@@ -410,7 +410,7 @@ mod protocol_tests {
         )?;
 
         // Append the StorageBid as an StorageScalar to the tree.
-        tree.push(bid.into())?;
+        tree.push(bid)?;
 
         // Extract the branch
         let branch = tree

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -51,7 +51,7 @@ mod protocol_tests {
         let (ck, vk) = pub_params.trim(1 << 16)?;
 
         // Generate a PoseidonTree and append the Bid.
-        let mut tree: PoseidonTree<_, Blake2b> = PoseidonTree::new(17usize);
+        let mut tree: PoseidonTree<Bid, _> = PoseidonTree::new(17usize);
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -113,6 +113,11 @@ mod protocol_tests {
         verifier.preprocess(&ck)?;
 
         let pi = verifier.mut_cs().public_inputs.clone();
+        for input in pi.iter().enumerate() {
+            if input.1 != &BlsScalar::zero() {
+                println!("{}", input.0);
+            }
+        }
         verifier.verify(&proof, &vk, &pi)
     }
 
@@ -154,7 +159,8 @@ mod protocol_tests {
             latest_consensus_step,
         )?;
 
-        // Edit the Score so that we try to get a bigger one than the one we should have got.
+        // Edit the Score so that we try to get a bigger one than the one we
+        // should have got.
         score.score = score.score + BlsScalar::from(100u64);
 
         // Proving
@@ -329,8 +335,9 @@ mod protocol_tests {
             latest_consensus_step,
         )?;
 
-        // Latest consensus step should be lower than the expiration_ts, in this case is not
-        // so the proof should fail since the Bid is expired at this round.
+        // Latest consensus step should be lower than the expiration_ts, in this
+        // case is not so the proof should fail since the Bid is expired
+        // at this round.
         let latest_consensus_round = BlsScalar::from(200u64);
 
         // Proving
@@ -365,8 +372,7 @@ mod protocol_tests {
         )?;
         verifier.preprocess(&ck)?;
 
-        let pi = verifier.mut_cs().public_inputs.clone();
-        // The proof should fail since it is expired.
+        let mut pi = verifier.mut_cs().public_inputs.clone();
         assert!(verifier.verify(&proof, &vk, &pi).is_err());
         Ok(())
     }
@@ -411,8 +417,9 @@ mod protocol_tests {
             .poseidon_branch(0u64)?
             .expect("Poseidon Branch Extraction");
 
-        // We first generate the score as if the bid was still eligible. Otherways
-        // the score generation would fail since the Bid wouldn't be elegible.
+        // We first generate the score as if the bid was still eligible.
+        // Otherways the score generation would fail since the Bid
+        // wouldn't be elegible.
         let latest_consensus_round = BlsScalar::from(3u64);
         let latest_consensus_step = BlsScalar::one();
         let consensus_round_seed = BlsScalar::random(&mut rng);
@@ -427,8 +434,9 @@ mod protocol_tests {
             latest_consensus_step,
         )?;
 
-        // Latest consensus step should be lower than the elegibility_ts, in this case is not
-        // so the proof should fail since the Bid is non elegible anymore.
+        // Latest consensus step should be lower than the elegibility_ts, in
+        // this case is not so the proof should fail since the Bid is
+        // non elegible anymore.
         let latest_consensus_round = BlsScalar::from(200u64);
 
         // Proving

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -113,11 +113,6 @@ mod protocol_tests {
         verifier.preprocess(&ck)?;
 
         let pi = verifier.mut_cs().public_inputs.clone();
-        for input in pi.iter().enumerate() {
-            if input.1 != &BlsScalar::zero() {
-                println!("{}", input.0);
-            }
-        }
         verifier.verify(&proof, &vk, &pi)
     }
 
@@ -372,7 +367,7 @@ mod protocol_tests {
         )?;
         verifier.preprocess(&ck)?;
 
-        let mut pi = verifier.mut_cs().public_inputs.clone();
+        let pi = verifier.mut_cs().public_inputs.clone();
         assert!(verifier.verify(&proof, &vk, &pi).is_err());
         Ok(())
     }


### PR DESCRIPTION
- Turn generate_prover_id fn public. This is needed by `rusk` since the proverId needs to be seen together with the proof of blindbid through the network.

- Moving this crate's version of `kelvin `to `0.18.0` so that now everything uses `PoseidonTree<Bid, Blake2b>. 
This was needed because we had two different versions of `kelvin` in usage at the same time and after checking it with @krl we found out that the divergency of versions was causing the problem and so, we downgraded the version of this repo.
 
- Updated `bid_preimage_gadget` so that now it preserver the linking of the `Variable`s used by circuits that require
this gadget.