### PR TITLE
Normalize crate name using dusk-blindbid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "blind_bid"
+name = "dusk-blindbid"
 version = "0.1.0"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 use anyhow::{Error, Result};
-use blind_bid::bid::Bid;
-use blind_bid::proof::BlindBidCircuit;
+use dusk_blindbid::bid::Bid;
+use dusk_blindbid::proof::BlindBidCircuit;
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
 use dusk_plonk::prelude::*;


### PR DESCRIPTION
As stated in #67 we should have a crate name which is inline with
the rest of crates that we currently have,

Closes #67