### PR TITLE
Add PI check for announced Scores

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -116,7 +116,7 @@ pub fn prove_correct_score_gadget(
     consensus_round_seed: AllocatedScalar,
     latest_consensus_round: AllocatedScalar,
     latest_consensus_step: AllocatedScalar,
-) -> Result<(), Error> {
+) -> Result<Variable, Error> {
     // Allocate constant one & zero values.
     let one = composer.add_witness_to_circuit_description(BlsScalar::one());
     let zero = composer.add_witness_to_circuit_description(BlsScalar::zero());
@@ -256,7 +256,7 @@ pub fn prove_correct_score_gadget(
         BlsScalar::zero(),
         BlsScalar::zero(),
     );
-    Ok(())
+    Ok(score_alloc_scalar.var)
 }
 
 // Given the y parameter, return the y' and it's inverse value.

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -115,6 +115,7 @@ mod protocol_tests {
             PublicInput::AffinePoint(bid.c, 0, 0),
             PublicInput::BlsScalar(-bid.hashed_secret, 0),
             PublicInput::BlsScalar(-prover_id, 0),
+            PublicInput::BlsScalar(-score.score, 0),
         ];
         circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
     }
@@ -134,9 +135,9 @@ mod protocol_tests {
         let bid = random_bid(&secret, secret_k)?;
         let secret: AffinePoint = (GENERATOR_EXTENDED * &secret).into();
         // Generate fields for the Bid & required by the compute_score
-        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
-        let latest_consensus_round = BlsScalar::random(&mut rand::thread_rng());
-        let latest_consensus_step = BlsScalar::random(&mut rand::thread_rng());
+        let consensus_round_seed = BlsScalar::from(50u64);
+        let latest_consensus_round = BlsScalar::from(50u64);
+        let latest_consensus_step = BlsScalar::from(50u64);
 
         // Append the StorageBid as an StorageScalar to the tree.
         tree.push(bid)?;
@@ -188,6 +189,7 @@ mod protocol_tests {
             PublicInput::AffinePoint(bid.c, 0, 0),
             PublicInput::BlsScalar(-bid.hashed_secret, 0),
             PublicInput::BlsScalar(-prover_id, 0),
+            PublicInput::BlsScalar(-score.score, 0),
         ];
         assert!(circuit
             .verify_proof(&pub_params, &vk, b"BidWithEditedScore", &proof, &pi)
@@ -264,6 +266,7 @@ mod protocol_tests {
             PublicInput::AffinePoint(bid.c, 0, 0),
             PublicInput::BlsScalar(-bid.hashed_secret, 0),
             PublicInput::BlsScalar(-prover_id, 0),
+            PublicInput::BlsScalar(-score.score, 0),
         ];
         assert!(circuit
             .verify_proof(&pub_params, &vk, b"EditedBidValue", &proof, &pi)
@@ -359,6 +362,7 @@ mod protocol_tests {
             PublicInput::AffinePoint(bid.c, 0, 0),
             PublicInput::BlsScalar(-bid.hashed_secret, 0),
             PublicInput::BlsScalar(-prover_id, 0),
+            PublicInput::BlsScalar(-score.score, 0),
         ];
         assert!(circuit
             .verify_proof(&pub_params, &vk, b"ExpiredBid", &proof, &pi)
@@ -455,6 +459,7 @@ mod protocol_tests {
             PublicInput::AffinePoint(bid.c, 0, 0),
             PublicInput::BlsScalar(-bid.hashed_secret, 0),
             PublicInput::BlsScalar(-prover_id, 0),
+            PublicInput::BlsScalar(-score.score, 0),
         ];
         assert!(circuit
             .verify_proof(&pub_params, &vk, b"NonElegibleBid", &proof, &pi)


### PR DESCRIPTION
We were missing this check and it's really important since
the Verifier had no way to determine wether the score that
he/she was recieving was indeed the one committed withiin
the Proof that is being verified.

- Added a PI check inside of the `gadget` fn to check that
indeed, the Score announced is the correct.
- Refactored tests to use this new PI.
- Make score_gen gadget to return a `Variable` as a result
instead of nothing.

Closes #74