### PR TITLE
Remap decryption errors to return dummy values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 


### PR DESCRIPTION
We currently have a problem which is that the gadget will fail if the decryption of the `PoseidonCypher` fails. This is a big issue since the verifier is not even interested in the real values. It just needs to fill the composer with dummy values.

The solution is described here:
- If the decryption fails, we just set the result to an impossible-to-obtain value.

On that way, verifiers do not get stuck on the process (they don't care) about the real values here (just about filling the
composer).  And provers won't get any info about if this secret can or not decrypt the cipher.

Bumps this crate version to `v0.2.1`