### PR TITLE
Write PI constructor in after gadget call

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -396,7 +396,8 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         // New Verifier instance
         let mut verifier = Verifier::new(transcript_initialisation);
         // Fill witnesses for Verifier
-        self.gadget(verifier.mut_cs())?;
+        let pi = self.gadget(verifier.mut_cs())?;
+        self.pi_constructor = Some(pi);
         verifier.verifier_key = Some(*verifier_key);
         verifier.verify(proof, &vk, &self.build_pi(pub_inputs)?)
     }


### PR DESCRIPTION
We were having an error since we were't compiling
the circuit and just using it.