### PR TITLE
Fix variable-circuit sizes issue on Score checking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -153,6 +153,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             -branch.root,
             composer.circuit_size(),
         ));
+
         // Constraint the bid_tree_root against a PI that represents
         // the root of the Bid tree that lives inside of the `Bid` contract.
         composer.constrain_to_constant(root, BlsScalar::zero(), -branch.root);
@@ -223,6 +224,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             composer.circuit_size(),
             composer.circuit_size() + 1,
         ));
+
         // Assert computed_commitment == announced commitment.
         composer.assert_equal_public_point(computed_c, bid.c);
 
@@ -237,6 +239,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             -bid.hashed_secret,
             composer.circuit_size(),
         ));
+
         // Constraint the secret_k_hash to be equal to the publicly avaliable
         // one.
         composer.constrain_to_constant(
@@ -395,6 +398,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         // Fill witnesses for Verifier
         let pi = self.gadget(verifier.mut_cs())?;
         self.pi_constructor = Some(pi);
+        let mut verifier = Verifier::new(transcript_initialisation);
         verifier.verifier_key = Some(*verifier_key);
         verifier.verify(proof, &vk, &self.build_pi(pub_inputs)?)
     }

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -217,11 +217,29 @@ pub fn prove_correct_score_gadget(
         BlsScalar::zero(),
     );
 
-    // 4. r2 < Y' we need a 128-bit range_proof
-    let should_be_1 = max_bound(composer, y_prime.scalar, score_alloc_scalar).0;
+    // 4. r2 < Y'
+    let r2_min_y_prime = composer.add(
+        (BlsScalar::one(), r2.var),
+        (-BlsScalar::one(), y_prime.var),
+        BlsScalar::zero(),
+        BlsScalar::zero(),
+    );
+    let r2_min_y_prime_scalar = r2.scalar - y_prime.scalar;
+    let r2_min_y_prime = AllocatedScalar {
+        var: r2_min_y_prime,
+        scalar: r2_min_y_prime_scalar,
+    };
+
+    // One indicates a failure here.
+    let should_be_one = max_bound(
+        composer,
+        BlsScalar::from(2u64).pow(&[128, 0, 0, 0]),
+        r2_min_y_prime,
+    );
+
     // Check that the result of the range_proof is indeed 0 to assert it passed.
     composer.constrain_to_constant(
-        should_be_1,
+        should_be_one.0,
         BlsScalar::one(),
         BlsScalar::zero(),
     );
@@ -256,6 +274,7 @@ pub fn prove_correct_score_gadget(
         BlsScalar::zero(),
         BlsScalar::zero(),
     );
+
     Ok(score_alloc_scalar.var)
 }
 

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -117,6 +117,19 @@ mod protocol_tests {
             PublicInput::BlsScalar(-prover_id, 0),
             PublicInput::BlsScalar(-score.score, 0),
         ];
+        use dusk_blindbid::score_gen::Score;
+        let mut circuit = BlindBidCircuit {
+            bid: Some(bid),
+            score: Some(Score::default()),
+            secret_k: Some(BlsScalar::one()),
+            secret: Some(AffinePoint::default()),
+            seed: Some(consensus_round_seed),
+            latest_consensus_round: Some(latest_consensus_round),
+            latest_consensus_step: Some(latest_consensus_step),
+            branch: Some(&branch),
+            size: 0,
+            pi_constructor: None,
+        };
         circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
     }
 


### PR DESCRIPTION
We were using a variable value to do our range checks.
Therefore, this was causing problems since the circuits
were varying constantly.

It has been addressed and solved.