### PR TITLE
Fix Variable-length circuit issues on round checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 


### PR DESCRIPTION
We were experiencing proving problems in
https://github.com/dusk-network/rusk/pull/80 due to the fact that
we were doing rangeproofs with variant max ranges.

This was causing the proofs to fail when they shouldnt since the
ProverKey & VerifierKey were basically incorrect for the circuits
that the proofs were addressed for.

This has been solved and now the constraints are done against
constant max bounds by subtracting the witnesses.