### PR TITLE
Apply new Circuit trait API for BlindBidCircuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.0"
 dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.2.0"}
-poseidon252 = {git = "https://github.com/dusk-network/poseidon252", tag = "v0.9.0"}
-dusk-plonk = {version = "0.2.11", features = ["trace-print"]}
+poseidon252 = {git = "https://github.com/dusk-network/poseidon252", tag = "v0.10.0"}
+dusk-plonk = {version = "0.3.1", features = ["trace-print"]}
 kelvin = "0.19.0"
 num-bigint = "0.3.0"
 num-traits = "0.2.11"
-plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.3.0"}
+plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.4.0"}
 thiserror = "1.0.20"
 rand_core = "0.5.1"
 lazy_static = "1.4.0"

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -468,7 +468,7 @@ mod protocol_tests {
         };
 
         let (pk, vk) = circuit.compile(&pub_params)?;
-        let proof = circuit.gen_proof(&pub_params, &pk, b"vec![]legibleBid")?;
+        let proof = circuit.gen_proof(&pub_params, &pk, b"NonElegibleBid")?;
         let storage_bid: StorageScalar = bid.into();
         let pi = vec![
             PublicInput::BlsScalar(branch.root(), 0),
@@ -479,7 +479,7 @@ mod protocol_tests {
             PublicInput::BlsScalar(score.score, 0),
         ];
         assert!(circuit
-            .verify_proof(&pub_params, &vk, b"vec![]legibleBid", &proof, &pi)
+            .verify_proof(&pub_params, &vk, b"NonElegibleBid", &proof, &pi)
             .is_err());
         Ok(())
     }

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -6,8 +6,8 @@
 
 #![allow(non_snake_case)]
 use anyhow::{Error, Result};
-use dusk_blindbid::bid::Bid;
 use dusk_blindbid::proof::BlindBidCircuit;
+use dusk_blindbid::{bid::Bid, score_gen::Score};
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::jubjub::{AffinePoint, GENERATOR_EXTENDED};
 use dusk_plonk::prelude::*;
@@ -94,41 +94,41 @@ mod protocol_tests {
         );
 
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(score),
-            secret_k: Some(secret_k),
-            secret: Some(secret),
-            seed: Some(consensus_round_seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: score,
+            secret_k: secret_k,
+            secret: secret,
+            seed: consensus_round_seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
 
-        let (pk, vk, _) = circuit.compile(&pub_params)?;
+        let (pk, vk) = circuit.compile(&pub_params)?;
         let proof = circuit.gen_proof(&pub_params, &pk, b"CorrectBid")?;
         let storage_bid: StorageScalar = bid.into();
         let pi = vec![
-            PublicInput::BlsScalar(-branch.root(), 0),
-            PublicInput::BlsScalar(-storage_bid.0, 0),
+            PublicInput::BlsScalar(branch.root(), 0),
+            PublicInput::BlsScalar(storage_bid.0, 0),
             PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(-bid.hashed_secret, 0),
-            PublicInput::BlsScalar(-prover_id, 0),
-            PublicInput::BlsScalar(-score.score, 0),
+            PublicInput::BlsScalar(bid.hashed_secret, 0),
+            PublicInput::BlsScalar(prover_id, 0),
+            PublicInput::BlsScalar(score.score, 0),
         ];
-        use dusk_blindbid::score_gen::Score;
+
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(Score::default()),
-            secret_k: Some(BlsScalar::one()),
-            secret: Some(AffinePoint::default()),
-            seed: Some(consensus_round_seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: Score::default(),
+            secret_k: BlsScalar::one(),
+            secret: AffinePoint::default(),
+            seed: consensus_round_seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
         circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
     }
@@ -181,29 +181,29 @@ mod protocol_tests {
         );
 
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(score),
-            secret_k: Some(secret_k),
-            secret: Some(secret),
-            seed: Some(consensus_round_seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: score,
+            secret_k: secret_k,
+            secret: secret,
+            seed: consensus_round_seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
 
-        let (pk, vk, _) = circuit.compile(&pub_params)?;
+        let (pk, vk) = circuit.compile(&pub_params)?;
         let proof =
             circuit.gen_proof(&pub_params, &pk, b"BidWithEditedScore")?;
         let storage_bid: StorageScalar = bid.into();
         let pi = vec![
-            PublicInput::BlsScalar(-branch.root(), 0),
-            PublicInput::BlsScalar(-storage_bid.0, 0),
+            PublicInput::BlsScalar(branch.root(), 0),
+            PublicInput::BlsScalar(storage_bid.0, 0),
             PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(-bid.hashed_secret, 0),
-            PublicInput::BlsScalar(-prover_id, 0),
-            PublicInput::BlsScalar(-score.score, 0),
+            PublicInput::BlsScalar(bid.hashed_secret, 0),
+            PublicInput::BlsScalar(prover_id, 0),
+            PublicInput::BlsScalar(score.score, 0),
         ];
         assert!(circuit
             .verify_proof(&pub_params, &vk, b"BidWithEditedScore", &proof, &pi)
@@ -260,28 +260,28 @@ mod protocol_tests {
         bid.hashed_secret = BlsScalar::from(63463245u64);
 
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(score),
-            secret_k: Some(secret_k),
-            secret: Some(secret),
-            seed: Some(consensus_round_seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: score,
+            secret_k: secret_k,
+            secret: secret,
+            seed: consensus_round_seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
 
-        let (pk, vk, _) = circuit.compile(&pub_params)?;
+        let (pk, vk) = circuit.compile(&pub_params)?;
         let proof = circuit.gen_proof(&pub_params, &pk, b"EditedBidValue")?;
         let storage_bid: StorageScalar = bid.into();
         let pi = vec![
-            PublicInput::BlsScalar(-branch.root(), 0),
-            PublicInput::BlsScalar(-storage_bid.0, 0),
+            PublicInput::BlsScalar(branch.root(), 0),
+            PublicInput::BlsScalar(storage_bid.0, 0),
             PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(-bid.hashed_secret, 0),
-            PublicInput::BlsScalar(-prover_id, 0),
-            PublicInput::BlsScalar(-score.score, 0),
+            PublicInput::BlsScalar(bid.hashed_secret, 0),
+            PublicInput::BlsScalar(prover_id, 0),
+            PublicInput::BlsScalar(score.score, 0),
         ];
         assert!(circuit
             .verify_proof(&pub_params, &vk, b"EditedBidValue", &proof, &pi)
@@ -357,28 +357,28 @@ mod protocol_tests {
         );
 
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(score),
-            secret_k: Some(secret_k),
-            secret: Some(secret),
-            seed: Some(consensus_round_seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: score,
+            secret_k: secret_k,
+            secret: secret,
+            seed: consensus_round_seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
 
-        let (pk, vk, _) = circuit.compile(&pub_params)?;
+        let (pk, vk) = circuit.compile(&pub_params)?;
         let proof = circuit.gen_proof(&pub_params, &pk, b"ExpiredBid")?;
         let storage_bid: StorageScalar = bid.into();
         let pi = vec![
-            PublicInput::BlsScalar(-branch.root(), 0),
-            PublicInput::BlsScalar(-storage_bid.0, 0),
+            PublicInput::BlsScalar(branch.root(), 0),
+            PublicInput::BlsScalar(storage_bid.0, 0),
             PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(-bid.hashed_secret, 0),
-            PublicInput::BlsScalar(-prover_id, 0),
-            PublicInput::BlsScalar(-score.score, 0),
+            PublicInput::BlsScalar(bid.hashed_secret, 0),
+            PublicInput::BlsScalar(prover_id, 0),
+            PublicInput::BlsScalar(score.score, 0),
         ];
         assert!(circuit
             .verify_proof(&pub_params, &vk, b"ExpiredBid", &proof, &pi)
@@ -455,31 +455,31 @@ mod protocol_tests {
         let latest_consensus_round = BlsScalar::from(200u64);
 
         let mut circuit = BlindBidCircuit {
-            bid: Some(bid),
-            score: Some(score),
-            secret_k: Some(secret_k),
-            secret: Some(secret),
-            seed: Some(consensus_round_seed),
-            latest_consensus_round: Some(latest_consensus_round),
-            latest_consensus_step: Some(latest_consensus_step),
-            branch: Some(&branch),
-            size: 0,
-            pi_constructor: None,
+            bid: bid,
+            score: score,
+            secret_k: secret_k,
+            secret: secret,
+            seed: consensus_round_seed,
+            latest_consensus_round: latest_consensus_round,
+            latest_consensus_step: latest_consensus_step,
+            branch: &branch,
+            trim_size: 1 << 15,
+            pi_positions: vec![],
         };
 
-        let (pk, vk, _) = circuit.compile(&pub_params)?;
-        let proof = circuit.gen_proof(&pub_params, &pk, b"NonElegibleBid")?;
+        let (pk, vk) = circuit.compile(&pub_params)?;
+        let proof = circuit.gen_proof(&pub_params, &pk, b"vec![]legibleBid")?;
         let storage_bid: StorageScalar = bid.into();
         let pi = vec![
-            PublicInput::BlsScalar(-branch.root(), 0),
-            PublicInput::BlsScalar(-storage_bid.0, 0),
+            PublicInput::BlsScalar(branch.root(), 0),
+            PublicInput::BlsScalar(storage_bid.0, 0),
             PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(-bid.hashed_secret, 0),
-            PublicInput::BlsScalar(-prover_id, 0),
-            PublicInput::BlsScalar(-score.score, 0),
+            PublicInput::BlsScalar(bid.hashed_secret, 0),
+            PublicInput::BlsScalar(prover_id, 0),
+            PublicInput::BlsScalar(score.score, 0),
         ];
         assert!(circuit
-            .verify_proof(&pub_params, &vk, b"NonElegibleBid", &proof, &pi)
+            .verify_proof(&pub_params, &vk, b"vec![]legibleBid", &proof, &pi)
             .is_err());
         Ok(())
     }


### PR DESCRIPTION
With the new version of `dusk-plonk` the Circuit trait definition
changed and therefore we need to update the BlindBidCircuit impl
accordingly.

- Refactored the `BlindBidCircuit` fields to not be an `Option`.
- Implemented the new trait methods.
- Changed the trim size that we got with the latest version of
Poseidon.
- Refactored tests to use `BlindBidCircuit` in the correct way.
- Replaced `size` field by `trim_size`.
- Rename `pi_constructor` to `pi_positions`.
- Update `poseidon252`, `plonk_gadgets` & `dusk-plonk` to their latest
versions.