### PR TITLE
Update lib dusk dependencies

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: dusk-analyzer
-          
-  test_nightly:
+
+  test_nightly_canon_std:
     name: Nightly tests canon + std
     runs-on: ubuntu-latest
-    env: 
+    env:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
@@ -37,12 +37,11 @@ jobs:
         with:
           command: test
           args: --release
-          
 
-  test_nightly:
+  test_nightly_nostd:
     name: Nightly tests no_std
     runs-on: ubuntu-latest
-    env: 
+    env:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
@@ -55,11 +54,11 @@ jobs:
         with:
           command: test
           args: --release --no-default-features
-   
-  test_nightly:
+
+  test_nightly_canon_nostd:
     name: Nightly tests no_std + canon
     runs-on: ubuntu-latest
-    env: 
+    env:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -24,6 +24,8 @@ jobs:
   test_nightly:
     name: Nightly tests canon + std
     runs-on: ubuntu-latest
+    env: 
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -35,14 +37,13 @@ jobs:
         with:
           command: test
           args: --release
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
+          
 
   test_nightly:
     name: Nightly tests no_std
     runs-on: ubuntu-latest
+    env: 
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -50,10 +51,6 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -62,6 +59,8 @@ jobs:
   test_nightly:
     name: Nightly tests no_std + canon
     runs-on: ubuntu-latest
+    env: 
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -69,10 +68,6 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,23 +5,24 @@ authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"
 edition = "2018"
 
 [dependencies]
-dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.4.1", default-features = false}
-poseidon252 = {git = "https://github.com/dusk-network/poseidon252", tag = "v0.15.0", default-features = false}
-dusk-bls12_381 = {version = "0.3", default-features = false}
-dusk-jubjub = {version = "0.5", default-features = false}
-dusk-plonk = {version = "0.3", features = ["trace-print"], optional = true}
+dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.5.1", default-features = false}
+poseidon252 = {git = "https://github.com/dusk-network/poseidon252", tag = "v0.17.0", default-features = false}
+dusk-bls12_381 = {version = "0.6", default-features = false}
+dusk-jubjub = {version = "0.8", default-features = false}
+dusk-plonk = {version = "0.5", features = ["trace-print"], optional = true}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
-plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.4.3", optional = true}
+plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.5.0", optional = true}
 rand_core = {version = "0.5", default-features = false}  
-lazy_static = "1.4.0"
+lazy_static = "1"
 rand = {version = "0.7", default-features = false, optional = true }
-canonical = { version = "0.4", optional = true }
-canonical_derive = { version = "0.4", optional = true }
+canonical = { version = "0.5", optional = true }
+canonical_derive = { version = "0.5", optional = true }
 anyhow = {version = "1", optional = true}
+dusk-bytes = "0.1"
 
 [dev-dependencies]
-canonical_host = "0.4"
+canonical_host = "0.5"
 
 [features]
 default = ["std", "canon"]

--- a/src/bid/bid.rs
+++ b/src/bid/bid.rs
@@ -15,17 +15,16 @@ use canonical::Store;
 use canonical_derive::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;
+use dusk_bytes::Serializable;
 use dusk_jubjub::{
     JubJubAffine, JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
 };
 use dusk_pki::{Ownable, StealthAddress};
 use poseidon252::cipher::PoseidonCipher;
-use poseidon252::sponge::sponge::sponge_hash;
+use poseidon252::sponge::hash as sponge_hash;
 #[cfg(feature = "std")]
 use poseidon252::tree::PoseidonLeaf;
 use rand_core::{CryptoRng, RngCore};
-#[cfg(feature = "std")]
-use std::io::{self, Read, Write};
 
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
@@ -60,6 +59,81 @@ impl Borrow<u64> for Bid {
     }
 }
 
+impl PartialEq for Bid {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash().eq(&other.hash())
+    }
+}
+
+// This needs to be between braces since const fn calls passed as const_generics
+// params aren't perfectly supported yet.
+impl Serializable<{ Bid::serialized_size() }> for Bid {
+    type Error = BlindBidError;
+
+    fn from_bytes(buf: &[u8; Self::SIZE]) -> Result<Bid, Self::Error> {
+        let mut one_cipher = [0u8; PoseidonCipher::cipher_size_bytes()];
+        let mut one_scalar = [0u8; 32];
+        let mut one_stealth_address = [0u8; 64];
+        let mut one_u64 = [0u8; 8];
+
+        one_cipher[..]
+            .copy_from_slice(&buf[0..PoseidonCipher::cipher_size_bytes()]);
+        let encrypted_data = PoseidonCipher::from_bytes(&one_cipher)?;
+
+        one_scalar[..]
+            .copy_from_slice(&buf[PoseidonCipher::cipher_size_bytes()..128]);
+        let nonce = BlsScalar::from_bytes(&one_scalar)?;
+
+        one_stealth_address[..].copy_from_slice(&buf[128..192]);
+        let stealth_address = StealthAddress::from_bytes(&one_stealth_address)?;
+
+        one_scalar[..].copy_from_slice(&buf[192..224]);
+        let hashed_secret = BlsScalar::from_bytes(&one_scalar)?;
+
+        one_scalar[..].copy_from_slice(&buf[224..256]);
+        let c = JubJubAffine::from_bytes(&one_scalar)?;
+
+        one_u64[..].copy_from_slice(&buf[256..264]);
+        let eligibility = u64::from_le_bytes(one_u64);
+
+        one_u64[..].copy_from_slice(&buf[264..272]);
+        let expiration = u64::from_le_bytes(one_u64);
+
+        one_u64[..].copy_from_slice(&buf[272..Bid::serialized_size()]);
+        let pos = u64::from_le_bytes(one_u64);
+
+        Ok(Bid {
+            encrypted_data,
+            nonce,
+            stealth_address,
+            hashed_secret,
+            c,
+            eligibility,
+            expiration,
+            pos,
+        })
+    }
+
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut buf = [0u8; Self::SIZE];
+        buf[0..PoseidonCipher::cipher_size_bytes()]
+            .copy_from_slice(&self.encrypted_data.to_bytes());
+        buf[PoseidonCipher::cipher_size_bytes()..128]
+            .copy_from_slice(&self.nonce.to_bytes());
+        buf[128..192].copy_from_slice(&self.stealth_address.to_bytes());
+        buf[192..224].copy_from_slice(&self.hashed_secret.to_bytes());
+        buf[224..256].copy_from_slice(&self.c.to_bytes());
+        buf[256..264].copy_from_slice(&self.eligibility.to_le_bytes());
+        buf[264..272].copy_from_slice(&self.expiration.to_le_bytes());
+        buf[272..Bid::serialized_size()]
+            .copy_from_slice(&self.pos.to_le_bytes());
+        buf
+    }
+}
+
+impl Eq for Bid {}
+
+// TODO: Remove probably. Ask team.
 #[cfg(all(feature = "canon", feature = "std"))]
 impl<S> PoseidonLeaf<S> for Bid
 where
@@ -84,6 +158,7 @@ impl Bid {
         PoseidonCipher::cipher_size_bytes() + 64 + 32 * 3 + 8 * 3
     }
 
+    /// Generates a new [Bid](self::Bid) from a rng source plus it's fields.  
     pub fn new<R>(
         rng: &mut R,
         stealth_address: &StealthAddress,
@@ -134,28 +209,6 @@ impl Bid {
         Ok(bid)
     }
 
-    pub(crate) fn set_value<R>(
-        &mut self,
-        rng: &mut R,
-        value: &JubJubScalar,
-        secret: &JubJubAffine,
-    ) where
-        R: RngCore + CryptoRng,
-    {
-        let blinder = JubJubScalar::random(rng);
-        self.nonce = BlsScalar::random(rng);
-        self.encrypted_data = PoseidonCipher::encrypt(
-            &[(*value).into(), blinder.into()],
-            secret,
-            &self.nonce,
-        );
-
-        self.c = JubJubAffine::from(
-            &(GENERATOR_EXTENDED * value)
-                + &(GENERATOR_NUMS_EXTENDED * blinder),
-        );
-    }
-
     /// One-time prover-id is stated to be `H(secret_k, sigma^s, k^t, k^s)`.
     ///
     /// The function performs the sponge_hash techniqe using poseidon to
@@ -176,7 +229,7 @@ impl Bid {
     }
 
     /// Decrypt the underlying data provided the secret of the bidder and return
-    /// a tuple containing the value and the blinder
+    /// a tuple containing the value and the blinder fields.
     pub fn decrypt_data(
         &self,
         secret: &JubJubAffine,
@@ -187,7 +240,6 @@ impl Bid {
                 let value = message[0];
                 let blinder = message[1];
 
-                // TODO - Follow-up the discussion over Fq -> Fr
                 let value =
                     JubJubScalar::from_raw(*value.reduce().internal_repr());
                 let blinder =
@@ -198,190 +250,25 @@ impl Bid {
             .map_err(|_| BlindBidError::WrongSecretProvided)
     }
 
-    // We cannot make this fn const since we need a mut buffer.
-    // mutable references in const fn are unstable
-    // see issue #57563 <https://github.com/rust-lang/rust/issues/57563>
-    /// Given a Bid, return the byte-representation of it.
-    pub fn to_bytes(&self) -> [u8; Bid::serialized_size()] {
-        let mut buf = [0u8; Bid::serialized_size()];
-        buf[0..PoseidonCipher::cipher_size_bytes()]
-            .copy_from_slice(&self.encrypted_data.to_bytes());
-        buf[PoseidonCipher::cipher_size_bytes()..128]
-            .copy_from_slice(&self.nonce.to_bytes());
-        buf[128..192].copy_from_slice(&self.stealth_address.to_bytes());
-        buf[192..224].copy_from_slice(&self.hashed_secret.to_bytes());
-        buf[224..256].copy_from_slice(&self.c.to_bytes());
-        buf[256..264].copy_from_slice(&self.eligibility.to_le_bytes());
-        buf[264..272].copy_from_slice(&self.expiration.to_le_bytes());
-        buf[272..Bid::serialized_size()]
-            .copy_from_slice(&self.pos.to_le_bytes());
-        buf
-    }
+    pub(crate) fn set_value<R>(
+        &mut self,
+        rng: &mut R,
+        value: &JubJubScalar,
+        secret: &JubJubAffine,
+    ) where
+        R: RngCore + CryptoRng,
+    {
+        let blinder = JubJubScalar::random(rng);
+        self.nonce = BlsScalar::random(rng);
+        self.encrypted_data = PoseidonCipher::encrypt(
+            &[(*value).into(), blinder.into()],
+            secret,
+            &self.nonce,
+        );
 
-    // We cannot make this fn const since we need a mut buffer.
-    // mutable references in const fn are unstable
-    // see issue #57563 <https://github.com/rust-lang/rust/issues/57563>
-    /// Given the byte-representation of a `Bid`, generate one instance of it.
-    pub fn from_bytes(
-        bytes: [u8; Bid::serialized_size()],
-    ) -> Result<Bid, BlindBidError> {
-        let mut one_cipher = [0u8; PoseidonCipher::cipher_size_bytes()];
-        let mut one_scalar = [0u8; 32];
-        let mut one_stealth_address = [0u8; 64];
-        let mut one_u64 = [0u8; 8];
-
-        one_cipher[..]
-            .copy_from_slice(&bytes[0..PoseidonCipher::cipher_size_bytes()]);
-        let encrypted_data = PoseidonCipher::from_bytes(&one_cipher)
-            .ok_or(BlindBidError::IOError)?;
-        one_scalar[..]
-            .copy_from_slice(&bytes[PoseidonCipher::cipher_size_bytes()..128]);
-        let nonce = read_scalar(&one_scalar)?;
-
-        one_stealth_address[..].copy_from_slice(&bytes[128..192]);
-        let stealth_address = StealthAddress::from_bytes(&one_stealth_address);
-        let stealth_address = match stealth_address {
-            Ok(address) => Ok(address),
-            Err(_) => Err(BlindBidError::IOError),
-        }?;
-
-        one_scalar[..].copy_from_slice(&bytes[192..224]);
-        let hashed_secret = read_scalar(&one_scalar)?;
-
-        one_scalar[..].copy_from_slice(&bytes[224..256]);
-        let c = read_jubjub_affine(&one_scalar)?;
-
-        one_u64[..].copy_from_slice(&bytes[256..264]);
-        let eligibility = u64::from_le_bytes(one_u64);
-
-        one_u64[..].copy_from_slice(&bytes[264..272]);
-        let expiration = u64::from_le_bytes(one_u64);
-
-        one_u64[..].copy_from_slice(&bytes[272..Bid::serialized_size()]);
-        let pos = u64::from_le_bytes(one_u64);
-
-        Ok(Bid {
-            encrypted_data,
-            nonce,
-            stealth_address,
-            hashed_secret,
-            c,
-            eligibility,
-            expiration,
-            pos,
-        })
-    }
-
-    /// Check if the bid is eligible for the provided block height
-    pub fn eligible(&self, block_height: &u64) -> bool {
-        &self.eligibility <= block_height && block_height <= &self.expiration
-    }
-}
-
-impl PartialEq for Bid {
-    fn eq(&self, other: &Self) -> bool {
-        self.hash().eq(&other.hash())
-    }
-}
-
-impl Eq for Bid {}
-
-#[cfg(feature = "std")]
-impl Read for Bid {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut buf = io::BufWriter::new(&mut buf[..]);
-        let mut n = 0;
-
-        n += buf.write(&self.encrypted_data.to_bytes())?;
-        n += buf.write(&self.nonce.to_bytes())?;
-        n += buf.write(&self.stealth_address.to_bytes())?;
-        n += buf.write(&self.hashed_secret.to_bytes())?;
-        n += buf.write(&self.c.to_bytes())?;
-        n += buf.write(&self.eligibility.to_le_bytes())?;
-        n += buf.write(&self.expiration.to_le_bytes())?;
-        n += buf.write(&self.pos.to_le_bytes())?;
-
-        buf.flush()?;
-        Ok(n)
-    }
-}
-
-fn read_scalar(one_scalar: &[u8; 32]) -> Result<BlsScalar, BlindBidError> {
-    let possible_scalar = BlsScalar::from_bytes(&one_scalar);
-    if possible_scalar.is_none().into() {
-        return Err(BlindBidError::IOError);
-    };
-    Ok(possible_scalar.unwrap())
-}
-
-fn read_jubjub_affine(
-    one_point: &[u8; 32],
-) -> Result<JubJubAffine, BlindBidError> {
-    let possible_scalar = JubJubAffine::from_bytes(*one_point);
-    if possible_scalar.is_none().into() {
-        return Err(BlindBidError::IOError);
-    };
-    Ok(possible_scalar.unwrap())
-}
-
-#[cfg(feature = "std")]
-impl Write for Bid {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut buf = io::BufReader::new(&buf[..]);
-
-        let mut one_cipher = [0u8; 96];
-        let mut one_scalar = [0u8; 32];
-        let mut one_stealth_address = [0u8; 64];
-        let mut one_u64 = [0u8; 8];
-
-        let mut n = 0;
-
-        buf.read_exact(&mut one_cipher)?;
-        n += one_cipher.len();
-        self.encrypted_data =
-            PoseidonCipher::from_bytes(&one_cipher).ok_or(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Could not recover PoseidonCipher from bytes"),
-            ))?;
-
-        buf.read_exact(&mut one_scalar)?;
-        n += one_scalar.len();
-        self.nonce = read_scalar(&one_scalar)?;
-
-        buf.read_exact(&mut one_stealth_address)?;
-        n += one_stealth_address.len();
-        self.stealth_address =
-            match StealthAddress::from_bytes(&one_stealth_address) {
-                Ok(address) => Ok(address),
-                Err(e) => Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("{:?}", e),
-                )),
-            }?;
-
-        buf.read_exact(&mut one_scalar)?;
-        n += one_scalar.len();
-        self.hashed_secret = read_scalar(&one_scalar)?;
-
-        buf.read_exact(&mut one_scalar)?;
-        n += one_scalar.len();
-        self.c = read_jubjub_affine(&one_scalar)?;
-
-        buf.read_exact(&mut one_scalar)?;
-        n += one_scalar.len();
-        self.eligibility = u64::from_le_bytes(one_u64);
-
-        buf.read_exact(&mut one_scalar)?;
-        n += one_scalar.len();
-        self.expiration = u64::from_le_bytes(one_u64);
-
-        buf.read_exact(&mut one_u64)?;
-        n += one_u64.len();
-        self.pos = u64::from_le_bytes(one_u64);
-        Ok(n)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
+        self.c = JubJubAffine::from(
+            &(GENERATOR_EXTENDED * value)
+                + &(GENERATOR_NUMS_EXTENDED * blinder),
+        );
     }
 }

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -15,8 +15,7 @@ use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
 #[cfg(feature = "std")]
 use dusk_plonk::prelude::*;
 #[cfg(feature = "std")]
-use poseidon252::sponge::gadget as sponge_hash_gadget;
-use poseidon252::sponge::hash as sponge_hash;
+use poseidon252::sponge;
 
 // 1. Generate the type_fields Scalar Id:
 // Type 1 will be BlsScalar
@@ -83,7 +82,7 @@ impl Bid {
         // Once all of the words are translated as `Scalar` and stored
         // correctly, apply the Poseidon sponge hash function to obtain
         // the encoded form of the `Bid`.
-        sponge_hash(&self.as_hash_inputs())
+        sponge::hash(&self.as_hash_inputs())
     }
 }
 
@@ -148,7 +147,7 @@ pub(crate) fn preimage_gadget(
     messages.push(pos);
 
     // Perform the sponge_hash inside of the Constraint System
-    sponge_hash_gadget(composer, &messages)
+    sponge::gadget(composer, &messages)
 }
 
 #[cfg(feature = "std")]
@@ -166,10 +165,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let secret_k = BlsScalar::from(*secret);
-        let pk_r = PublicSpendKey::from(SecretSpendKey::new(
-            JubJubScalar::one(),
-            -JubJubScalar::one(),
-        ));
+        let pk_r = PublicSpendKey::from(SecretSpendKey::random(&mut rng));
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -14,7 +14,6 @@ use dusk_bytes::Serializable;
 use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
 #[cfg(feature = "std")]
 use dusk_plonk::prelude::*;
-#[cfg(feature = "std")]
 use poseidon252::sponge;
 
 // 1. Generate the type_fields Scalar Id:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,8 +40,8 @@ pub enum BlindBidError {
     WrongSecretProvided,
     /// Invalid encoding/decoding
     IOError,
-    /// Serde Error
-    SerdeErr(DuskBytesError),
+    /// Dusk-bytes serialization error
+    SerializationError(DuskBytesError),
 }
 
 #[cfg(feature = "std")]
@@ -63,6 +63,6 @@ impl From<BlindBidError> for std::io::Error {
 
 impl From<DuskBytesError> for BlindBidError {
     fn from(bytes_err: DuskBytesError) -> Self {
-        Self::SerdeErr(bytes_err)
+        Self::SerializationError(bytes_err)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@
 
 //! Errors related to the BlindBid module
 
+use dusk_bytes::Error as DuskBytesError;
 use dusk_jubjub::JubJubScalar;
 #[cfg(feature = "std")]
 use std::fmt;
@@ -39,6 +40,8 @@ pub enum BlindBidError {
     WrongSecretProvided,
     /// Invalid encoding/decoding
     IOError,
+    /// Serde Error
+    SerdeErr(DuskBytesError),
 }
 
 #[cfg(feature = "std")]
@@ -55,5 +58,11 @@ impl From<BlindBidError> for std::io::Error {
             std::io::ErrorKind::InvalidData,
             format!("{:?}", err),
         )
+    }
+}
+
+impl From<DuskBytesError> for BlindBidError {
+    fn from(bytes_err: DuskBytesError) -> Self {
+        Self::SerdeErr(bytes_err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! BlindBid impl
 #![allow(non_snake_case)]
+#![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod bid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 
 //! BlindBid impl
 #![allow(non_snake_case)]
-#![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod bid;

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -7,7 +7,7 @@
 //! BlindBidProof module.
 use crate::bid::{encoding::preimage_gadget, Bid};
 use crate::score_gen::{score::prove_correct_score_gadget, Score};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_plonk::constraint_system::ecc::{
@@ -16,7 +16,7 @@ use dusk_plonk::constraint_system::ecc::{
 use dusk_plonk::prelude::*;
 use plonk_gadgets::{AllocatedScalar, RangeGadgets::max_bound};
 use poseidon252::{
-    sponge::sponge::sponge_hash_gadget,
+    sponge::gadget as sponge_hash_gadget,
     tree::{merkle_opening as merkle_opening_gadget, PoseidonBranch},
 };
 
@@ -67,7 +67,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         let bid_stealth_addr = (
             Point::from_private_affine(
                 composer,
-                bid.stealth_address.pk_r().into(),
+                bid.stealth_address.pk_r().as_ref().into(),
             ),
             Point::from_private_affine(
                 composer,
@@ -106,7 +106,8 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             AllocatedScalar::allocate(composer, decrypted_data[1]);
         // Allocate the bid tree root to be used later by the score_generation
         // gadget.
-        let bid_tree_root = AllocatedScalar::allocate(composer, branch.root());
+        let bid_tree_root =
+            AllocatedScalar::allocate(composer, branch.root().clone());
 
         // ------------------------------------------------------- //
         //                                                         //
@@ -290,10 +291,6 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             latest_consensus_round,
             latest_consensus_step,
         );
-        let computed_score = match computed_score {
-            Ok(score) => Ok(score),
-            Err(e) => Err(anyhow!(format!("{:?}", e))),
-        }?;
 
         // Constraint the score to be the public one and set it in the PI
         // constructor.

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -16,7 +16,7 @@ use dusk_plonk::constraint_system::ecc::{
 use dusk_plonk::prelude::*;
 use plonk_gadgets::{AllocatedScalar, RangeGadgets::max_bound};
 use poseidon252::{
-    sponge::gadget as sponge_hash_gadget,
+    sponge,
     tree::{merkle_opening as merkle_opening_gadget, PoseidonBranch},
 };
 
@@ -230,7 +230,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         composer.range_gate(bid_value.var, 64usize);
 
         // 7. `m = H(k)` Secret key pre-image check.
-        let secret_k_hash = sponge_hash_gadget(composer, &[secret_k.var]);
+        let secret_k_hash = sponge::gadget(composer, &[secret_k.var]);
         // Add PI constraint for the secret_k_hash.
         pi.push(PublicInput::BlsScalar(
             -bid.hashed_secret,
@@ -248,7 +248,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         // We generate the prover_id and constrain it to a public input
         // On that way we bind the Score to the correct id.
         // 8. `prover_id = H(secret_k, sigma^s, k^t, k^s)`. Preimage check
-        let prover_id = sponge_hash_gadget(
+        let prover_id = sponge::gadget(
             composer,
             &[
                 secret_k.var,

--- a/src/score_gen/mod.rs
+++ b/src/score_gen/mod.rs
@@ -23,7 +23,7 @@ pub struct Score {
 }
 
 impl Score {
-    pub(crate) fn new(
+    pub fn new(
         score: BlsScalar,
         y: BlsScalar,
         y_prime: BlsScalar,

--- a/src/score_gen/score.rs
+++ b/src/score_gen/score.rs
@@ -10,8 +10,8 @@
 use super::Score;
 use crate::bid::Bid;
 use crate::errors::BlindBidError;
-use anyhow::{Error as AnyhowError, Result};
 use dusk_bls12_381::BlsScalar;
+use dusk_bytes::Serializable;
 use dusk_jubjub::JubJubAffine;
 use dusk_plonk::prelude::*;
 use num_bigint::BigUint;
@@ -19,8 +19,8 @@ use num_traits::{One, Zero};
 use plonk_gadgets::{
     AllocatedScalar, RangeGadgets::max_bound, ScalarGadgets::maybe_equal,
 };
+use poseidon252::sponge::gadget as sponge_hash_gadget;
 use poseidon252::sponge::hash as sponge_hash;
-use poseidon252::sponge::sponge::sponge_hash_gadget;
 
 pub(self) const SCALAR_FIELD_ORD_DIV_2_POW_128: BlsScalar =
     BlsScalar::from_raw([
@@ -112,7 +112,7 @@ pub fn prove_correct_score_gadget(
     consensus_round_seed: AllocatedScalar,
     latest_consensus_round: AllocatedScalar,
     latest_consensus_step: AllocatedScalar,
-) -> Result<Variable, AnyhowError> {
+) -> Variable {
     // Allocate constant one & zero values.
     let one = composer.add_witness_to_circuit_description(BlsScalar::one());
     let zero = composer.add_witness_to_circuit_description(BlsScalar::zero());
@@ -271,7 +271,7 @@ pub fn prove_correct_score_gadget(
         BlsScalar::zero(),
     );
 
-    Ok(score_alloc_scalar.var)
+    score_alloc_scalar.var
 }
 
 /// Given the y parameter, return the y' and it's inverse value.
@@ -290,6 +290,7 @@ fn biguint_to_scalar(biguint: BigUint) -> Result<BlsScalar, BlindBidError> {
 mod tests {
     use super::*;
     use anyhow::Result;
+    use dusk_bytes::Serializable;
     use dusk_pki::{PublicSpendKey, SecretSpendKey};
     use dusk_plonk::jubjub::GENERATOR_EXTENDED;
     use rand::Rng;
@@ -298,7 +299,10 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let secret_k = BlsScalar::random(&mut rng);
-        let pk_r = PublicSpendKey::from(SecretSpendKey::default());
+        let pk_r = PublicSpendKey::from(SecretSpendKey::new(
+            JubJubScalar::one(),
+            -JubJubScalar::one(),
+        ));
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())

--- a/tests/bid_tests.rs
+++ b/tests/bid_tests.rs
@@ -10,20 +10,16 @@
 
 mod tree_assets;
 use anyhow::Result;
-use canonical::Store;
 use canonical_host::MemStore;
 use dusk_blindbid::proof::BlindBidCircuit;
 use dusk_blindbid::{bid::Bid, score_gen::Score};
+use dusk_blindbid::{V_RAW_MAX, V_RAW_MIN};
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::jubjub::{JubJubAffine, GENERATOR_EXTENDED};
 use dusk_plonk::prelude::*;
-use poseidon252::tree::{PoseidonBranch, PoseidonMaxAnnotation, PoseidonTree};
 use rand::Rng;
-use tree_assets::{BidLeaf, BidTree};
-
-const V_RAW_MIN: u64 = 50_000u64;
-const V_RAW_MAX: u64 = 250_000u64;
+use tree_assets::BidTree;
 
 fn random_bid(secret: &JubJubScalar, secret_k: BlsScalar) -> Bid {
     let mut rng = rand::thread_rng();
@@ -33,8 +29,7 @@ fn random_bid(secret: &JubJubScalar, secret_k: BlsScalar) -> Bid {
     ));
     let stealth_addr = pk_r.gen_stealth_address(&secret);
     let secret = GENERATOR_EXTENDED * secret;
-    let value: u64 =
-        (&mut rand::thread_rng()).gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+    let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
     let value = JubJubScalar::from(value);
     // Set the timestamps as the max values so the proofs do not fail for them
     // (never expired or non-elegible).
@@ -325,8 +320,8 @@ mod protocol_tests {
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = JubJubAffine::from(GENERATOR_EXTENDED * secret);
         let secret_k = BlsScalar::random(&mut rng);
-        let value: u64 = (&mut rand::thread_rng())
-            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+        let value: u64 =
+            (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let expiration_ts = 100u64;
         let elegibility_ts = 1000u64;
@@ -427,8 +422,8 @@ mod protocol_tests {
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = JubJubAffine::from(GENERATOR_EXTENDED * secret);
         let secret_k = BlsScalar::random(&mut rng);
-        let value: u64 = (&mut rand::thread_rng())
-            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+        let value: u64 =
+            (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let expiration_ts = 100u64;
         let elegibility_ts = 1000u64;

--- a/tests/tree_assets.rs
+++ b/tests/tree_assets.rs
@@ -1,0 +1,104 @@
+#![allow(non_snake_case)]
+#![cfg(feature = "canon")]
+#![cfg(feature = "std")]
+
+use canonical::{Canon, Store};
+use canonical_derive::Canon;
+use core::borrow::Borrow;
+use dusk_blindbid::bid::Bid;
+use dusk_bls12_381::BlsScalar;
+use poseidon252::tree::{
+    PoseidonBranch, PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree,
+};
+
+#[derive(Debug, Clone, Copy, Canon)]
+pub struct BidLeaf(pub(crate) Bid);
+
+impl BidLeaf {
+    /// Generates a new BidLeaf instance from a `Bid`.
+    pub fn new(bid: Bid) -> Self {
+        BidLeaf(bid)
+    }
+
+    /// Returns the internal bid representation of the `BidLeaf` as with
+    /// the `Bid` type.
+    pub fn bid(&self) -> Bid {
+        self.0
+    }
+
+    /// Returns a &mut to the internal bid representation of the `BidLeaf`
+    /// as with the `Bid` type.
+    pub fn bid_mut(&mut self) -> &mut Bid {
+        &mut self.0
+    }
+}
+
+impl Borrow<u64> for BidLeaf {
+    fn borrow(&self) -> &u64 {
+        &self.0.pos
+    }
+}
+
+impl From<Bid> for BidLeaf {
+    fn from(bid: Bid) -> BidLeaf {
+        BidLeaf(bid)
+    }
+}
+
+impl From<BidLeaf> for Bid {
+    fn from(leaf: BidLeaf) -> Bid {
+        leaf.0
+    }
+}
+
+impl<S> PoseidonLeaf<S> for BidLeaf
+where
+    S: Store,
+{
+    fn poseidon_hash(&self) -> BlsScalar {
+        self.0.hash()
+    }
+
+    fn pos(&self) -> u64 {
+        self.0.pos
+    }
+
+    fn set_pos(&mut self, pos: u64) {
+        self.0.pos = pos;
+    }
+}
+
+pub struct BidTree<S: Store>(
+    PoseidonTree<BidLeaf, PoseidonMaxAnnotation, S, 17usize>,
+);
+
+impl<S> BidTree<S>
+where
+    S: Store,
+{
+    /// Constructor
+    pub fn new() -> Self {
+        Self(PoseidonTree::new())
+    }
+
+    /// Get a bid from a provided index
+    #[allow(dead_code)]
+    pub fn get(&self, idx: u64) -> Option<BidLeaf> {
+        self.0.get(idx as usize).unwrap()
+    }
+
+    /// Append a bid to the tree and return its index
+    ///
+    /// The index will be the last available position
+    pub fn push(&mut self, bid: BidLeaf) -> usize {
+        self.0.push(bid).unwrap()
+    }
+
+    /// Returns a poseidon branch pointing at the specific index
+    pub fn poseidon_branch(
+        &self,
+        idx: usize,
+    ) -> Option<PoseidonBranch<17usize>> {
+        self.0.branch(idx).unwrap()
+    }
+}

--- a/tests/tree_assets.rs
+++ b/tests/tree_assets.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 #![allow(non_snake_case)]
 #![cfg(feature = "canon")]
 #![cfg(feature = "std")]


### PR DESCRIPTION
This PR closes #100 by updating all deps.

- Include and substitute serde fn's by `dusk-bytes` crate ones.
- Remove legacy functions or code.