### PR TITLE
Set elegibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 22-02-21
+
+### Added
+
+- Added `set_eligibility` for `Bid`. [#121](https://github.com/dusk-network/dusk-blindbid/issues/125)
+
 ## [0.7.0] - 17-02-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -273,6 +273,11 @@ impl Bid {
         self.eligibility
     }
 
+    /// Sets a new value for the eligibility of the Bid.
+    pub fn set_eligibility(&mut self, new_eligibility: u64) {
+        self.eligibility = new_eligibility;
+    }
+
     /// Returns the `expiration` field of the Bid.
     pub fn expiration(&self) -> u64 {
         self.expiration


### PR DESCRIPTION
As it was stated in #125 we needed to enable
this API otherways the Bid contract cannot set
the elegibility time correctly for new Bids.

Closes #125 and unblocks https://github.com/dusk-network/rusk/issues/51