### PR TITLE
Update dusk-plonk and canonical and related dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ dusk-bytes = "0.1"
 cfg-if = "1.0"
 
 [dev-dependencies]
-microkelvin = "0.7.1"
+microkelvin = "0.7"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ exclude = [
 ]
 
 [dependencies]
-dusk-pki = {version = "0.7.0-rc.0", default-features = false}
-dusk-poseidon = {version = "0.21.0-rc.0", default-features = false }
-dusk-bls12_381 = {version = "0.8.0-rc.0", default-features = false}
-dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
-dusk-plonk = {version = "0.8.0-rc.1", optional = true}
+dusk-pki = {version = "0.7.0-rc", default-features = false}
+dusk-poseidon = {version = "0.21.0-rc", default-features = false }
+dusk-bls12_381 = {version = "0.8.0-rc", default-features = false}
+dusk-jubjub = {version = "0.10.0-rc", default-features = false}
+dusk-plonk = {version = "0.8.0-rc", optional = true}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
-plonk_gadgets = {version = "0.6.0-rc.0", optional = true}
+plonk_gadgets = {version = "0.6.0-rc", optional = true}
 rand_core = {version = "0.6", default-features = false}  
 lazy_static = "1.4"
 canonical = { version = "0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,25 +18,26 @@ exclude = [
 ]
 
 [dependencies]
-dusk-pki = {version = "0.6", default-features = false}
-dusk-poseidon = {version = "0.18", default-features = false }
-dusk-bls12_381 = {version = "0.6", default-features = false}
-dusk-jubjub = {version = "0.8", default-features = false}
-dusk-plonk = {version = "0.5", features = ["trace-print"], optional = true}
+dusk-pki = {version = "0.7.0-rc.0", default-features = false}
+dusk-poseidon = {version = "0.21.0-rc.0", default-features = false }
+dusk-bls12_381 = {version = "0.8.0-rc.0", default-features = false}
+dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
+dusk-plonk = {version = "0.8.0-rc.1", optional = true}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
-plonk_gadgets = {version = "0.5", optional = true}
-rand_core = {version = "0.5", default-features = false}  
-lazy_static = "1"
-rand = {version = "0.7", default-features = false, optional = true }
-canonical = { version = "0.5", optional = true }
-canonical_derive = { version = "0.5", optional = true }
+plonk_gadgets = {version = "0.6.0-rc.0", optional = true}
+rand_core = {version = "0.6", default-features = false}  
+lazy_static = "1.4"
+canonical = { version = "0.6", optional = true }
+canonical_derive = { version = "0.6", optional = true }
+rand = {version = "0.8"}
 anyhow = {version = "1", optional = true}
 dusk-bytes = "0.1"
 cfg-if = "1.0"
 
 [dev-dependencies]
-canonical_host = "0.5"
+microkelvin = "0.7.1"
+
 
 [features]
 default = ["std", "canon"]
@@ -49,8 +50,6 @@ std = [
     "plonk_gadgets",
     "num-bigint",
     "num-traits",
-    "rand/default",
-    "rand_core/std",
 ]
 canon = [
     "canonical",
@@ -58,3 +57,4 @@ canon = [
     "dusk-poseidon/canon",
     "dusk-pki/canon",
 ]
+

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -15,8 +15,6 @@ pub(crate) mod score;
 use crate::errors::BlindBidError;
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
 use core::borrow::Borrow;

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -290,8 +290,8 @@ impl Bid {
     }
 
     /// Returns the `pos` field of the Bid.
-    pub fn pos(&self) -> u64 {
-        self.pos
+    pub fn pos(&self) -> &u64 {
+        &self.pos
     }
 
     /// Sets a new value for the position of the Bid.
@@ -389,7 +389,7 @@ mod bid_serialization {
             let stealth_addr = pk_r.gen_stealth_address(&secret);
             let secret = GENERATOR_EXTENDED * secret;
             let value: u64 =
-                (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+                (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
             let value = JubJubScalar::from(value);
             // Set the timestamps as the max values so the proofs do not fail
             // for them (never expired or non-elegible).

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -155,7 +155,6 @@ mod tests {
     use super::*;
     use anyhow::Result;
     use dusk_pki::{PublicSpendKey, SecretSpendKey};
-    use dusk_plonk::constraint_system::ecc::Point;
     use dusk_plonk::jubjub::GENERATOR_EXTENDED;
     use plonk_gadgets::AllocatedScalar;
     use rand::Rng;

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -168,7 +168,7 @@ mod tests {
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())
-            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+            .gen_range(crate::V_RAW_MIN..crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
 
         let eligibility = u64::MAX;
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn bid_preimage_gadget() -> Result<()> {
+    fn bid_preimage_gadget() -> Result<(), Error> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 14, &mut rand::thread_rng())?;
@@ -212,16 +212,10 @@ mod tests {
                 composer.add_input(bid.encrypted_data.cipher()[0]),
                 composer.add_input(bid.encrypted_data.cipher()[1]),
             );
-            let bid_commitment = Point::from_private_affine(composer, bid.c);
+            let bid_commitment = composer.add_affine(bid.c);
             let bid_stealth_addr = (
-                Point::from_private_affine(
-                    composer,
-                    bid.stealth_address.pk_r().as_ref().into(),
-                ),
-                Point::from_private_affine(
-                    composer,
-                    bid.stealth_address.R().into(),
-                ),
+                composer.add_affine(bid.stealth_address.pk_r().as_ref().into()),
+                composer.add_affine(bid.stealth_address.R().into()),
             );
             let eligibility = AllocatedScalar::allocate(
                 composer,
@@ -249,7 +243,7 @@ mod tests {
             composer.constrain_to_constant(
                 bid_hash,
                 BlsScalar::zero(),
-                -storage_bid,
+                Some(-storage_bid),
             );
         };
         // Proving
@@ -262,7 +256,7 @@ mod tests {
         let mut verifier = Verifier::new(b"testing");
         circuit(verifier.mut_cs(), &bid);
         verifier.preprocess(&ck)?;
-        let pi = verifier.mut_cs().public_inputs.clone();
+        let pi = verifier.mut_cs().construct_dense_pi_vec();
         verifier.verify(&proof, &vk, &pi)
     }
 }

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -228,7 +228,7 @@ impl Score {
             two_pow_128,
             -BlsScalar::one(),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // 3.(r1 < |Fr|/2^128 AND Y' < 2^128) OR (r1 = |Fr|/2^128 AND Y' < |Fr|
         // mod 2^128).
@@ -269,7 +269,7 @@ impl Score {
             first_cond,
             second_cond,
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // (r1 = |Fr|/2^128 AND Y' < |Fr| mod 2^128)
         let right_assign = composer.mul(
@@ -277,7 +277,7 @@ impl Score {
             third_cond,
             fourth_cond,
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // left_assign XOR right_assign = 1
         // This is possible since condition 1. and 3. are mutually exclusive.
@@ -295,7 +295,7 @@ impl Score {
             BlsScalar::one(),
             BlsScalar::zero(),
             -BlsScalar::one(),
-            BlsScalar::zero(),
+            None,
         );
 
         // 4. r2 < Y'
@@ -303,7 +303,7 @@ impl Score {
             (BlsScalar::one(), r2.var),
             (-BlsScalar::one(), y_prime.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         let r2_min_y_prime_scalar = r2.scalar - y_prime.scalar;
         let r2_min_y_prime = AllocatedScalar {
@@ -320,11 +320,7 @@ impl Score {
 
         // Check that the result of the range_proof is indeed 0 to assert it
         // passed.
-        composer.constrain_to_constant(
-            should_be_one.0,
-            BlsScalar::one(),
-            BlsScalar::zero(),
-        );
+        composer.constrain_to_constant(should_be_one.0, BlsScalar::one(), None);
 
         // 5. q < 2^120
         composer.range_gate(score_alloc_scalar.var, 120usize);
@@ -336,14 +332,14 @@ impl Score {
             score_alloc_scalar.var,
             y_prime.var,
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // q*Y' + r2
         let left = composer.add(
             (BlsScalar::one(), f_y_prime_prod),
             (BlsScalar::one(), r2.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // (q*Y' + r2) - v*2^128 = 0
         composer.add_gate(
@@ -354,7 +350,7 @@ impl Score {
             -two_pow_128,
             BlsScalar::zero(),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
 
         score_alloc_scalar.var
@@ -392,7 +388,7 @@ mod tests {
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())
-            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+            .gen_range(crate::V_RAW_MIN..crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let eligibility = u64::MAX;
         let expiration = u64::MAX;
@@ -454,7 +450,7 @@ mod tests {
     }
 
     #[test]
-    fn correct_score_gen_proof() -> Result<()> {
+    fn correct_score_gen_proof() -> Result<(), Error> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -6,12 +6,8 @@
 
 //! Score generation
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "canon")] {
-        use canonical::Canon;
-        use canonical_derive::Canon;
-    }
-}
+#[cfg(feature = "canon")]
+use canonical_derive::Canon;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -66,9 +66,6 @@ use anyhow::Result;
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_pki::Ownable;
-use dusk_plonk::constraint_system::ecc::{
-    scalar_mul::fixed_base::scalar_mul, Point,
-};
 use dusk_plonk::prelude::*;
 use dusk_poseidon::{
     sponge,
@@ -114,8 +111,6 @@ mod tree_assets;
 ///     latest_consensus_round: BlsScalar::from(latest_consensus_round),
 ///     latest_consensus_step: BlsScalar::from(latest_consensus_step),
 ///     branch: &branch,
-///     trim_size: 1 << 15,
-///     pi_positions: vec![],
 /// };
 /// circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
 /// ```
@@ -138,14 +133,11 @@ pub struct BlindBidCircuit<'a> {
     pub branch: &'a PoseidonBranch<17>,
     /// Secret that derypts the Cipher.
     pub secret: JubJubAffine,
-    /// Trim size of the Public Parameters used by the PLONK mechanism.
-    pub trim_size: usize,
-    /// Positions of the Public Inputs used with the proof.
-    pub pi_positions: Vec<PublicInput>,
 }
 
-impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
-    fn gadget(&mut self, composer: &mut StandardComposer) -> Result<()> {
+impl<'a> Circuit for BlindBidCircuit<'a> {
+    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
+    fn gadget(&mut self, composer: &mut StandardComposer) -> Result<(), Error> {
         // Check if the inputs were indeed pre-loaded inside of the circuit
         // structure.
         let bid = self.bid;
@@ -156,8 +148,6 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         let latest_consensus_step = self.latest_consensus_step;
         let score = self.score;
         let secret = self.secret;
-        // Instantiate PI vector.
-        let pi = self.get_mut_pi_positions();
         // Get the corresponding `StorageBid` value that for the `Bid`
         // which is effectively the value of the proven leaf (hash of the Bid)
         // and allocate it.
@@ -170,17 +160,10 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             composer.add_input(bid.encrypted_data().cipher()[0]),
             composer.add_input(bid.encrypted_data().cipher()[1]),
         );
-        let bid_commitment =
-            Point::from_private_affine(composer, bid.commitment());
+        let bid_commitment = composer.add_affine(bid.commitment());
         let bid_stealth_addr = (
-            Point::from_private_affine(
-                composer,
-                bid.stealth_address().pk_r().as_ref().into(),
-            ),
-            Point::from_private_affine(
-                composer,
-                bid.stealth_address().R().into(),
-            ),
+            composer.add_affine(bid.stealth_address().pk_r().as_ref().into()),
+            composer.add_affine(bid.stealth_address().R().into()),
         );
         let bid_eligibility_ts = AllocatedScalar::allocate(
             composer,
@@ -191,7 +174,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             BlsScalar::from(bid.expiration()),
         );
         let pos =
-            AllocatedScalar::allocate(composer, BlsScalar::from(bid.pos()));
+            AllocatedScalar::allocate(composer, BlsScalar::from(*bid.pos()));
         // Allocate bid-needed inputs
         let secret_k = AllocatedScalar::allocate(composer, secret_k);
         let seed = AllocatedScalar::allocate(composer, seed);
@@ -223,16 +206,15 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         // ------------------------------------------------------- //
 
         // 1. Merkle Opening
-        let root = merkle_opening_gadget(composer, branch, bid_hash.var);
-        // Add PI constraint for the root to the PI constructor
-        pi.push(PublicInput::BlsScalar(
-            -branch.root(),
-            composer.circuit_size(),
-        ));
+        let root = merkle_opening_gadget(composer, branch);
 
         // Constraint the bid_tree_root against a PI that represents
         // the root of the Bid tree that lives inside of the `Bid` contract.
-        composer.constrain_to_constant(root, BlsScalar::zero(), -branch.root());
+        composer.constrain_to_constant(
+            root,
+            BlsScalar::zero(),
+            Some(-branch.root()),
+        );
 
         // 2. Bid pre_image check
         let computed_bid_hash = preimage_gadget(
@@ -246,16 +228,11 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             pos.var,
         );
 
-        // Add PI constraint for bid preimage check.
-        pi.push(PublicInput::BlsScalar(
-            -bid_hash.scalar,
-            composer.circuit_size(),
-        ));
         // Constraint the hash to be equal to the real one
         composer.constrain_to_constant(
             computed_bid_hash,
             BlsScalar::zero(),
-            -bid_hash.scalar,
+            Some(-bid_hash.scalar),
         );
 
         // 3. t_a >= k_t
@@ -264,7 +241,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             (BlsScalar::one(), latest_consensus_round.var),
             (-BlsScalar::one(), bid_eligibility_ts.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         let kt_min_ta_scalar =
             latest_consensus_round.scalar - bid_eligibility_ts.scalar;
@@ -282,11 +259,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         .0;
         // Constraint third condition to be one.
         // So basically, that the rangeproof does not hold.
-        composer.constrain_to_constant(
-            third_cond,
-            BlsScalar::one(),
-            BlsScalar::zero(),
-        );
+        composer.constrain_to_constant(third_cond, BlsScalar::one(), None);
 
         // 4. t_e >= k_t
         // k_t - t_e should be > 2^64 which is the max size of the round.
@@ -294,7 +267,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             (BlsScalar::one(), latest_consensus_round.var),
             (-BlsScalar::one(), bid_expiration.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         let kt_min_te_scalar =
             latest_consensus_round.scalar - bid_expiration.scalar;
@@ -312,22 +285,14 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         .0;
         // Constraint third condition to be one.
         // So basically, that the rangeproof does not hold.
-        composer.constrain_to_constant(
-            fourth_cond,
-            BlsScalar::one(),
-            BlsScalar::zero(),
-        );
+        composer.constrain_to_constant(fourth_cond, BlsScalar::one(), None);
 
         // 5. c = C(v, b) Pedersen Commitment check
-        let p1 = scalar_mul(composer, bid_value.var, GENERATOR_EXTENDED);
-        let p2 = scalar_mul(composer, bid_blinder.var, GENERATOR_NUMS_EXTENDED);
-        let computed_c = p1.point().fast_add(composer, *p2.point());
-        // Add PI constraint for the commitment computation check.
-        pi.push(PublicInput::AffinePoint(
-            bid.commitment(),
-            composer.circuit_size(),
-            composer.circuit_size() + 1,
-        ));
+        let p1 =
+            composer.fixed_base_scalar_mul(bid_value.var, GENERATOR_EXTENDED);
+        let p2 = composer
+            .fixed_base_scalar_mul(bid_blinder.var, GENERATOR_NUMS_EXTENDED);
+        let computed_c = composer.point_addition_gate(p1, p2);
 
         // Assert computed_commitment == announced commitment.
         composer.assert_equal_public_point(computed_c, bid.commitment());
@@ -338,18 +303,13 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
 
         // 7. `m = H(k)` Secret key pre-image check.
         let secret_k_hash = sponge::gadget(composer, &[secret_k.var]);
-        // Add PI constraint for the secret_k_hash.
-        pi.push(PublicInput::BlsScalar(
-            -bid.hashed_secret(),
-            composer.circuit_size(),
-        ));
 
         // Constraint the secret_k_hash to be equal to the publicly avaliable
         // one.
         composer.constrain_to_constant(
             secret_k_hash,
             BlsScalar::zero(),
-            -bid.hashed_secret(),
+            Some(-bid.hashed_secret()),
         );
 
         // We generate the prover_id and constrain it to a public input
@@ -365,26 +325,15 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             ],
         );
 
-        // Constraint the prover_id to be the public one and set it in the PI
-        // constructor.
-        pi.push(PublicInput::BlsScalar(
-            -bid.generate_prover_id(
-                secret_k.scalar,
-                seed.scalar,
-                latest_consensus_round.scalar,
-                latest_consensus_step.scalar,
-            ),
-            composer.circuit_size(),
-        ));
         composer.constrain_to_constant(
             prover_id,
             BlsScalar::zero(),
-            -bid.generate_prover_id(
+            Some(-bid.generate_prover_id(
                 secret_k.scalar,
                 seed.scalar,
                 latest_consensus_round.scalar,
                 latest_consensus_step.scalar,
-            ),
+            )),
         );
 
         // 9. Score generation circuit check with the corresponding gadget.
@@ -398,33 +347,15 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             latest_consensus_step,
         );
 
-        // Constraint the score to be the public one and set it in the PI
-        // constructor.
-        pi.push(PublicInput::BlsScalar(
-            -score.value(),
-            composer.circuit_size(),
-        ));
         composer.constrain_to_constant(
             computed_score,
             BlsScalar::zero(),
-            -score.value(),
+            Some(-score.value()),
         );
         Ok(())
     }
 
-    fn get_pi_positions(&self) -> &Vec<PublicInput> {
-        &self.pi_positions
-    }
-
-    fn get_mut_pi_positions(&mut self) -> &mut Vec<PublicInput> {
-        &mut self.pi_positions
-    }
-
-    fn get_trim_size(&self) -> usize {
-        self.trim_size
-    }
-
-    fn set_trim_size(&mut self, size: usize) {
-        self.trim_size = size;
+    fn padded_circuit_size(&self) -> usize {
+        1 << 15
     }
 }

--- a/src/proof/bid_tests.rs
+++ b/src/proof/bid_tests.rs
@@ -65,7 +65,7 @@ mod protocol_tests {
         let latest_consensus_step = 50u64;
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -115,16 +115,6 @@ mod protocol_tests {
             score.value().into(),
         ];
 
-        let mut circuit = BlindBidCircuit {
-            bid,
-            score: Score::default(),
-            secret_k: BlsScalar::one(),
-            secret: JubJubAffine::default(),
-            seed: BlsScalar::from(consensus_round_seed),
-            latest_consensus_round: BlsScalar::from(latest_consensus_round),
-            latest_consensus_step: BlsScalar::from(latest_consensus_step),
-            branch: &branch,
-        };
         circuit::verify_proof(
             &pub_params,
             &vd.key(),
@@ -155,7 +145,7 @@ mod protocol_tests {
         let latest_consensus_step = 50u64;
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -241,7 +231,7 @@ mod protocol_tests {
         let latest_consensus_step = 25519u64;
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -338,7 +328,7 @@ mod protocol_tests {
         .expect("Bid creation error");
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -443,7 +433,7 @@ mod protocol_tests {
         .expect("Bid creation error");
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =

--- a/src/proof/bid_tests.rs
+++ b/src/proof/bid_tests.rs
@@ -9,7 +9,6 @@
 use super::tree_assets::BidTree;
 use crate::{Bid, BlindBidCircuit, BlindBidError, Score, V_RAW_MAX, V_RAW_MIN};
 use anyhow::Result;
-use canonical_host::MemStore;
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::jubjub::{JubJubAffine, GENERATOR_EXTENDED};
@@ -24,7 +23,7 @@ fn random_bid(secret: &JubJubScalar, secret_k: BlsScalar) -> Bid {
     ));
     let stealth_addr = pk_r.gen_stealth_address(&secret);
     let secret = GENERATOR_EXTENDED * secret;
-    let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+    let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
     let value = JubJubScalar::from(value);
     // Set the timestamps as the max values so the proofs do not fail for them
     // (never expired or non-elegible).
@@ -47,13 +46,13 @@ fn random_bid(secret: &JubJubScalar, secret_k: BlsScalar) -> Bid {
 mod protocol_tests {
     use super::*;
     #[test]
-    fn correct_blindbid_proof() -> Result<()> {
+    fn correct_blindbid_proof() -> Result<(), Error> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -69,9 +68,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // Generate a `Score` for our Bid with the consensus parameters
         let score = Score::compute(
@@ -101,22 +99,20 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"CorrectBid")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.commitment(), 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.commitment().into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
 
         let mut circuit = BlindBidCircuit {
@@ -128,10 +124,15 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
-        circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
+        circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"CorrectBid",
+        )
     }
 
     #[test]
@@ -141,7 +142,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -157,9 +158,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // Generate a `Score` for our Bid with the consensus parameters
         let mut score = Score::compute(
@@ -192,27 +192,31 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof =
             circuit.gen_proof(&pub_params, &pk, b"BidWithEditedScore")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"BidWithEditedScore", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"BidWithEditedScore"
+        )
+        .is_err());
         Ok(())
     }
 
@@ -223,7 +227,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -240,9 +244,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // Generate a `Score` for our Bid with the consensus parameters
         let score = Score::compute(
@@ -275,26 +278,30 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"EditedBidValue")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"EditedBidValue", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"EditedBidValue"
+        )
+        .is_err());
         Ok(())
     }
 
@@ -305,7 +312,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Create an expired bid.
         let mut rng = rand::thread_rng();
@@ -315,7 +322,7 @@ mod protocol_tests {
         let secret = JubJubAffine::from(GENERATOR_EXTENDED * secret);
         let secret_k = BlsScalar::random(&mut rng);
         let value: u64 =
-            (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+            (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let expiration_ts = 100u64;
         let elegibility_ts = 1000u64;
@@ -334,9 +341,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // We first generate the score as if the bid wasn't expired. Otherways
         // the score generation would fail since the Bid would be expired.
@@ -377,26 +383,30 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"ExpiredBid")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"ExpiredBid", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"ExpiredBid"
+        )
+        .is_err());
         Ok(())
     }
 
@@ -407,7 +417,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Create a non-elegible Bid.
         let mut rng = rand::thread_rng();
@@ -417,7 +427,7 @@ mod protocol_tests {
         let secret = JubJubAffine::from(GENERATOR_EXTENDED * secret);
         let secret_k = BlsScalar::random(&mut rng);
         let value: u64 =
-            (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+            (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let expiration_ts = 100u64;
         let elegibility_ts = 1000u64;
@@ -436,9 +446,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // We first generate the score as if the bid was still eligible.
         // Otherways the score generation would fail since the Bid
@@ -480,26 +489,30 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"NonElegibleBid")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"NonElegibleBid", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"NonElegibleBid"
+        )
+        .is_err());
         Ok(())
     }
 }

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -14,6 +14,7 @@ use dusk_bls12_381::BlsScalar;
 use dusk_poseidon::tree::{
     PoseidonBranch, PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree,
 };
+use microkelvin::Keyed;
 
 #[derive(Debug, Clone, Copy, Canon)]
 pub struct BidLeaf(pub(crate) Bid);
@@ -55,16 +56,13 @@ impl From<BidLeaf> for Bid {
     }
 }
 
-impl<S> PoseidonLeaf<S> for BidLeaf
-where
-    S: Store,
-{
+impl PoseidonLeaf for BidLeaf {
     fn poseidon_hash(&self) -> BlsScalar {
         self.0.hash()
     }
 
     fn pos(&self) -> u64 {
-        self.0.pos()
+        *self.0.pos()
     }
 
     fn set_pos(&mut self, pos: u64) {
@@ -72,37 +70,10 @@ where
     }
 }
 
-pub struct BidTree<S: Store>(
-    PoseidonTree<BidLeaf, PoseidonMaxAnnotation, S, 17usize>,
-);
-
-impl<S> BidTree<S>
-where
-    S: Store,
-{
-    /// Constructor
-    pub fn new() -> Self {
-        Self(PoseidonTree::new())
-    }
-
-    /// Get a bid from a provided index
-    #[allow(dead_code)]
-    pub fn get(&self, idx: u64) -> Option<BidLeaf> {
-        self.0.get(idx as usize).unwrap()
-    }
-
-    /// Append a bid to the tree and return its index
-    ///
-    /// The index will be the last available position
-    pub fn push(&mut self, bid: BidLeaf) -> usize {
-        self.0.push(bid).unwrap()
-    }
-
-    /// Returns a poseidon branch pointing at the specific index
-    pub fn poseidon_branch(
-        &self,
-        idx: usize,
-    ) -> Option<PoseidonBranch<17usize>> {
-        self.0.branch(idx).unwrap()
+impl Keyed<u64> for BidLeaf {
+    fn key(&self) -> &u64 {
+        &self.0.pos()
     }
 }
+
+pub type BidTree = PoseidonTree<BidLeaf, PoseidonMaxAnnotation, 17>;

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -7,13 +7,10 @@
 #![allow(non_snake_case)]
 
 use crate::Bid;
-use canonical::{Canon, Store};
 use canonical_derive::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;
-use dusk_poseidon::tree::{
-    PoseidonBranch, PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree,
-};
+use dusk_poseidon::tree::{PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree};
 use microkelvin::Keyed;
 
 #[derive(Debug, Clone, Copy, Canon)]


### PR DESCRIPTION
- Update `dusk-pki` from `v0.6` to `v0.7.0-rc.0`.
- Update `dusk-poseidon` from `v0.20.0` to `v0.21.0-rc.0`.
- Update `dusk-bls12_381` from `v0.6.0` to `v0.8.0-rc.0`.
- Update `dusk-jubjub` from `v0.8.0` to `v0.10.0-rc.0`.
- Update `dusk-plonk` from `v0.5` to `v0.8.0-rc.1`.
- Update `rand-core` from `v0.5` to `v0.6`.
- Update `canonical` from `v0.5` to `v0.6`.
- Update `rand` from `v0.7` to `v0.8`.
- Update `plonk_gadgets` from `v0.5` to `v0.6.0-rc.0`.
- Remove `MemStore` references from tests.
- Remove `canonical-host` from dev-deps.
- Update tests according to the new `dusk-plonk` API.
- Change `Bid::pos` method to return &u64 instead of `u64` directly.

Resolves: #127, #129