### PR TITLE
Refactor error module and crate error handling

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release
+          args: --release --features std
 
   test_nightly_nostd:
     name: Nightly tests no_std
@@ -53,7 +53,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --no-default-features
+          args: --release --no-default-features 
 
   test_nightly_canon_nostd:
     name: Nightly tests no_std + canon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 012-02-21
+
 ### Changed
+
 - Use crates.io deps for `dusk-pki` and `plonk_gadgets` now that they're published.[#116](https://github.com/dusk-network/dusk-blindbid/issues/116)
 - Improve naming for `Score` gen function [#118](https://github.com/dusk-network/dusk-blindbid/issues/118)
 - Consensus round seed as BlsScalar instead of u64 [#113](https://github.com/dusk-network/dusk-blindbid/issues/113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Refactor error module to include plonk & poseidon err variants. [#131](https://github.com/dusk-network/dusk-blindbid/issues/131)
+- Change error module to include plonk & poseidon err variants [#131](https://github.com/dusk-network/dusk-blindbid/issues/131)
+- Change crate features to not require `std` to use `proof` mod. [#135](https://github.com/dusk-network/dusk-blindbid/issues/135)
+- Change API getters returning by ref and not by value. [#124](https://github.com/dusk-network/dusk-blindbid/issues/124)
 
 ### Removed
-- Remove `anyhow` from the crate. [#131](https://github.com/dusk-network/dusk-blindbid/issues/131)
+- Remove `anyhow` from the crate [#131](https://github.com/dusk-network/dusk-blindbid/issues/131)
 
 ## [0.7.1] - 22-02-21
 
 ### Added
 
-- Added `set_eligibility` for `Bid`. [#125](https://github.com/dusk-network/dusk-blindbid/issues/125)
+- Add `set_eligibility` for `Bid` [#125](https://github.com/dusk-network/dusk-blindbid/issues/125)
 
 ## [0.7.0] - 17-02-21
 
 ### Added
 
-- Added `extend_expiration()` for `Bid`. [#121](https://github.com/dusk-network/dusk-blindbid/issues/121)
+- Add `extend_expiration()` for `Bid` [#121](https://github.com/dusk-network/dusk-blindbid/issues/121)
 
 ### Changed
 
-- Changed `Bid::set_pos()` to not return `&mut u64`. [#121](https://github.com/dusk-network/dusk-blindbid/issues/121)
+- Change `Bid::set_pos()` to not return `&mut u64` [#121](https://github.com/dusk-network/dusk-blindbid/issues/121)
 
 ## [0.6.0] - 12-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Refactor error module to include plonk & poseidon err variants. [#131](https://github.com/dusk-network/dusk-blindbid/issues/131)
+
+### Removed
+- Remove `anyhow` from the crate. [#131](https://github.com/dusk-network/dusk-blindbid/issues/131)
+
 ## [0.7.1] - 22-02-21
 
 ### Added
 
-- Added `set_eligibility` for `Bid`. [#121](https://github.com/dusk-network/dusk-blindbid/issues/125)
+- Added `set_eligibility` for `Bid`. [#125](https://github.com/dusk-network/dusk-blindbid/issues/125)
 
 ## [0.7.0] - 17-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
+- Use crates.io deps for `dusk-pki` and `plonk_gadgets` now that they're published.[#116](https://github.com/dusk-network/dusk-blindbid/issues/116)
 - Improve naming for `Score` gen function [#118](https://github.com/dusk-network/dusk-blindbid/issues/118)
 - Consensus round seed as BlsScalar instead of u64 [#113](https://github.com/dusk-network/dusk-blindbid/issues/113)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 012-02-21
+## [0.7.0] - 17-02-21
+
+### Added
+
+- Added `extend_expiration()` for `Bid`. [#121](https://github.com/dusk-network/dusk-blindbid/issues/121)
+
+### Changed
+
+- Changed `Bid::set_pos()` to not return `&mut u64`. [#121](https://github.com/dusk-network/dusk-blindbid/issues/121)
+
+## [0.6.0] - 12-02-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve naming for `Score` gen function [#118](https://github.com/dusk-network/dusk-blindbid/issues/118)
 - Consensus round seed as BlsScalar instead of u64 [#113](https://github.com/dusk-network/dusk-blindbid/issues/113)
 
 ## [0.5.1] - 02-02-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Consensus round seed as BlsScalar instead of u64 [#113](https://github.com/dusk-network/dusk-blindbid/issues/113)
+
+## [0.5.1] - 02-02-21
+
+### Changed
+
+- Update dusk-pki to latest version
+
+## [0.5.0] - 27-01-21
+
+### Added
+
+- Added docs for the entire repo [#107](https://github.com/dusk-network/dusk-blindbid/issues/107)
+
+### Changed
+
+- Migrate repo to 2018 edition [#104](https://github.com/dusk-network/dusk-blindbid/issues/104)
+- Update deps to latest versions [#103](https://github.com/dusk-network/dusk-blindbid/issues/103)
+- Restructure the entire API of the crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 22-02-21
+
+### Added
+
+- Added `set_eligibility` for `Bid`. [#121](https://github.com/dusk-network/dusk-blindbid/issues/125)
+
 ## [0.7.0] - 17-02-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
 dusk-plonk = {version = "0.8.0-rc.1", default-features = false, features = ["alloc"]}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
-plonk_gadgets = {version = "0.6.0-rc.0", optional = true}
+plonk_gadgets = {version = "0.6.0-rc", optional = true}
 rand_core = {version = "0.6", default-features = false}  
 lazy_static = "1.4"
 canonical = { version = "0.6", optional = true }
@@ -35,7 +35,7 @@ dusk-bytes = "0.1"
 cfg-if = "1.0"
 
 [dev-dependencies]
-microkelvin = "0.7.1"
+microkelvin = "0.7"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ lazy_static = "1.4"
 canonical = { version = "0.6", optional = true }
 canonical_derive = { version = "0.6", optional = true }
 rand = {version = "0.8"}
-anyhow = {version = "1", optional = true}
 dusk-bytes = "0.1"
 cfg-if = "1.0"
 
@@ -42,7 +41,6 @@ microkelvin = "0.7.1"
 [features]
 default = ["std", "canon"]
 std = [
-    "anyhow",
     "dusk-jubjub/std",
     "dusk-bls12_381/std",
     "dusk-plonk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-dusk-pki = {version = "0.6", tag = "v0.6.0", default-features = false}
+dusk-pki = {version = "0.6", default-features = false}
 dusk-poseidon = {version = "0.18", default-features = false }
 dusk-bls12_381 = {version = "0.6", default-features = false}
 dusk-jubjub = {version = "0.8", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ exclude = [
 ]
 
 [dependencies]
-dusk-pki = {version = "0.7.0-rc.0", default-features = false}
-dusk-poseidon = {version = "0.21.0-rc.0", default-features = false }
-dusk-bls12_381 = {version = "0.8.0-rc.0", default-features = false}
-dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
-dusk-plonk = {version = "0.8.0-rc.1", default-features = false, features = ["alloc"]}
+dusk-pki = {version = "0.7.0-rc", default-features = false}
+dusk-poseidon = {version = "0.21.0-rc", default-features = false }
+dusk-bls12_381 = {version = "0.8.0-rc", default-features = false}
+dusk-jubjub = {version = "0.10.0-rc", default-features = false}
+dusk-plonk = {version = "0.8.0-rc", default-features = false, features = ["alloc"]}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
 plonk_gadgets = {version = "0.6.0-rc", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ exclude = [
 ]
 
 [dependencies]
-dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.5.3", default-features = false}
-poseidon252 = {git = "https://github.com/dusk-network/poseidon252", tag = "v0.17.0", default-features = false}
+dusk-pki = {version = "0.6", tag = "v0.6.0", default-features = false}
+dusk-poseidon = {version = "0.18", default-features = false }
 dusk-bls12_381 = {version = "0.6", default-features = false}
 dusk-jubjub = {version = "0.8", default-features = false}
 dusk-plonk = {version = "0.5", features = ["trace-print"], optional = true}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
-plonk_gadgets = {git = "https://github.com/dusk-network/plonk_gadgets", tag = "v0.5.0", optional = true}
+plonk_gadgets = {version = "0.5", optional = true}
 rand_core = {version = "0.5", default-features = false}  
 lazy_static = "1"
 rand = {version = "0.7", default-features = false, optional = true }
@@ -45,7 +45,7 @@ std = [
     "dusk-jubjub/std",
     "dusk-bls12_381/std",
     "dusk-plonk",
-    "poseidon252/default",
+    "dusk-poseidon/default",
     "plonk_gadgets",
     "num-bigint",
     "num-traits",
@@ -55,6 +55,6 @@ std = [
 canon = [
     "canonical",
     "canonical_derive",
-    "poseidon252/canon",
+    "dusk-poseidon/canon",
     "dusk-pki/canon",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dusk-pki = {version = "0.7.0-rc.0", default-features = false}
 dusk-poseidon = {version = "0.21.0-rc.0", default-features = false }
 dusk-bls12_381 = {version = "0.8.0-rc.0", default-features = false}
 dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
-dusk-plonk = {version = "0.8.0-rc.1", optional = true}
+dusk-plonk = {version = "0.8.0-rc.1", default-features = false, features = ["alloc"]}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
 plonk_gadgets = {version = "0.6.0-rc.0", optional = true}
@@ -43,12 +43,13 @@ default = ["std", "canon"]
 std = [
     "dusk-jubjub/std",
     "dusk-bls12_381/std",
-    "dusk-plonk",
+    "dusk-plonk/std",
     "dusk-poseidon/default",
     "plonk_gadgets",
     "num-bigint",
     "num-traits",
 ]
+
 canon = [
     "canonical",
     "canonical_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-blindbid"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["CPerezz <carlos@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,25 +18,26 @@ exclude = [
 ]
 
 [dependencies]
-dusk-pki = {version = "0.6", default-features = false}
-dusk-poseidon = {version = "0.18", default-features = false }
-dusk-bls12_381 = {version = "0.6", default-features = false}
-dusk-jubjub = {version = "0.8", default-features = false}
-dusk-plonk = {version = "0.5", features = ["trace-print"], optional = true}
+dusk-pki = {version = "0.7.0-rc.0", default-features = false}
+dusk-poseidon = {version = "0.21.0-rc.0", default-features = false }
+dusk-bls12_381 = {version = "0.8.0-rc.0", default-features = false}
+dusk-jubjub = {version = "0.10.0-rc.0", default-features = false}
+dusk-plonk = {version = "0.8.0-rc.1", optional = true}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
-plonk_gadgets = {version = "0.5", optional = true}
-rand_core = {version = "0.5", default-features = false}  
-lazy_static = "1"
-rand = {version = "0.7", default-features = false, optional = true }
-canonical = { version = "0.5", optional = true }
-canonical_derive = { version = "0.5", optional = true }
+plonk_gadgets = {version = "0.6.0-rc.0", optional = true}
+rand_core = {version = "0.6", default-features = false}  
+lazy_static = "1.4"
+canonical = { version = "0.6", optional = true }
+canonical_derive = { version = "0.6", optional = true }
+rand = {version = "0.8"}
 anyhow = {version = "1", optional = true}
 dusk-bytes = "0.1"
 cfg-if = "1.0"
 
 [dev-dependencies]
-canonical_host = "0.5"
+microkelvin = "0.7.1"
+
 
 [features]
 default = ["std", "canon"]
@@ -49,8 +50,6 @@ std = [
     "plonk_gadgets",
     "num-bigint",
     "num-traits",
-    "rand/default",
-    "rand_core/std",
 ]
 canon = [
     "canonical",
@@ -58,3 +57,4 @@ canon = [
     "dusk-poseidon/canon",
     "dusk-pki/canon",
 ]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ dusk-jubjub = {version = "0.10.0-rc", default-features = false}
 dusk-plonk = {version = "0.8.0-rc", default-features = false, features = ["alloc"]}
 num-bigint = {version = "0.3", optional = true } 
 num-traits = {version = "0.2", optional = true } 
-plonk_gadgets = {version = "0.6.0-rc", optional = true}
+plonk_gadgets = {version = "0.6.0-rc"}
 rand_core = {version = "0.6", default-features = false}  
 lazy_static = "1.4"
 canonical = { version = "0.6", optional = true }
 canonical_derive = { version = "0.6", optional = true }
-rand = {version = "0.8"}
+rand = "0.8"
 dusk-bytes = "0.1"
 cfg-if = "1.0"
 
@@ -39,17 +39,16 @@ microkelvin = "0.7"
 
 
 [features]
-default = ["std", "canon"]
+default = ["canon"]
 std = [
     "dusk-jubjub/std",
     "dusk-bls12_381/std",
     "dusk-plonk/std",
     "dusk-poseidon/default",
-    "plonk_gadgets",
+    "plonk_gadgets/std",
     "num-bigint",
     "num-traits",
 ]
-
 canon = [
     "canonical",
     "canonical_derive",

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -15,8 +15,6 @@ pub(crate) mod score;
 use crate::errors::BlindBidError;
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
 use core::borrow::Borrow;

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -366,7 +366,6 @@ impl Bid {
     }
 }
 
-#[cfg(feature = "std")]
 #[cfg(test)]
 mod bid_serialization {
     use super::*;

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -26,8 +26,8 @@ use dusk_jubjub::{
     JubJubAffine, JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
 };
 use dusk_pki::{Ownable, StealthAddress};
-use poseidon252::cipher::PoseidonCipher;
-use poseidon252::sponge;
+use dusk_poseidon::cipher::PoseidonCipher;
+use dusk_poseidon::sponge;
 use rand_core::{CryptoRng, RngCore};
 pub use score::Score;
 
@@ -46,10 +46,10 @@ pub use score::Score;
 /// verification.
 ///
 /// The Bid is also designed to be stored within a
-/// [PoseidonTree](poseidon252::tree::PoseidonTree). Although it's not
+/// [PoseidonTree](dusk_poseidon::tree::PoseidonTree). Although it's not
 /// responsability of this crate to provide such implementation. To make that
 /// happen, make sure to implement
-/// [PoseidonLeaf](poseidon252::tree::PoseidonLeaf) trait for it or a wrapper
+/// [PoseidonLeaf](dusk_poseidon::tree::PoseidonLeaf) trait for it or a wrapper
 /// structure.
 /// # Example
 /// ```ignore

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -290,8 +290,8 @@ impl Bid {
     }
 
     /// Returns the `pos` field of the Bid.
-    pub fn pos(&self) -> u64 {
-        self.pos
+    pub fn pos(&self) -> &u64 {
+        &self.pos
     }
 
     /// Sets a new value for the position of the Bid.
@@ -389,7 +389,7 @@ mod bid_serialization {
             let stealth_addr = pk_r.gen_stealth_address(&secret);
             let secret = GENERATOR_EXTENDED * secret;
             let value: u64 =
-                (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+                (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
             let value = JubJubScalar::from(value);
             // Set the timestamps as the max values so the proofs do not fail
             // for them (never expired or non-elegible).

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -278,15 +278,20 @@ impl Bid {
         self.expiration
     }
 
+    /// Returns a mutable ref pointing to the `pos` field of the
+    /// Bid.
+    pub fn extend_expiration(&mut self, extension: u64) {
+        self.expiration += extension;
+    }
+
     /// Returns the `pos` field of the Bid.
     pub fn pos(&self) -> u64 {
         self.pos
     }
 
-    /// Returns a mutable ref pointing to the `pos` field of the
-    /// Bid.
-    pub fn set_pos(&mut self) -> &mut u64 {
-        &mut self.pos
+    /// Sets a new value for the position of the Bid.
+    pub fn set_pos(&mut self, new_pos: u64) {
+        self.pos = new_pos;
     }
 
     /// Performs the [sponge_hash](sponge::hash) techniqe using poseidon to

--- a/src/bid.rs
+++ b/src/bid.rs
@@ -273,6 +273,11 @@ impl Bid {
         self.eligibility
     }
 
+    /// Sets a new value for the eligibility of the Bid.
+    pub fn set_eligibility(&mut self, new_eligibility: u64) {
+        self.eligibility = new_eligibility;
+    }
+
     /// Returns the `expiration` field of the Bid.
     pub fn expiration(&self) -> u64 {
         self.expiration

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -14,7 +14,7 @@ use dusk_bytes::Serializable;
 use dusk_plonk::constraint_system::ecc::Point as PlonkPoint;
 #[cfg(feature = "std")]
 use dusk_plonk::prelude::*;
-use poseidon252::sponge;
+use dusk_poseidon::sponge;
 
 // 1. Generate the type_fields Scalar Id:
 // Type 1 will be BlsScalar
@@ -97,7 +97,7 @@ impl Into<BlsScalar> for Bid {
     }
 }
 
-/// Hashes the internal Bid parameters using the Poseidon252 hash
+/// Hashes the internal Bid parameters using the Poseidon hash
 /// function and the cannonical encoding for hashing returning a
 /// Variable which contains the hash of the Bid.
 #[cfg(feature = "std")]

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -153,7 +153,6 @@ pub(crate) fn preimage_gadget(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::Result;
     use dusk_pki::{PublicSpendKey, SecretSpendKey};
     use dusk_plonk::jubjub::GENERATOR_EXTENDED;
     use plonk_gadgets::AllocatedScalar;

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -155,7 +155,6 @@ mod tests {
     use super::*;
     use anyhow::Result;
     use dusk_pki::{PublicSpendKey, SecretSpendKey};
-    use dusk_plonk::constraint_system::ecc::Point;
     use dusk_plonk::jubjub::GENERATOR_EXTENDED;
     use plonk_gadgets::AllocatedScalar;
     use rand::Rng;

--- a/src/bid/encoding.rs
+++ b/src/bid/encoding.rs
@@ -168,7 +168,7 @@ mod tests {
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())
-            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+            .gen_range(crate::V_RAW_MIN..crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
 
         let eligibility = u64::MAX;
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn bid_preimage_gadget() -> Result<()> {
+    fn bid_preimage_gadget() -> Result<(), Error> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 14, &mut rand::thread_rng())?;
@@ -212,16 +212,10 @@ mod tests {
                 composer.add_input(bid.encrypted_data.cipher()[0]),
                 composer.add_input(bid.encrypted_data.cipher()[1]),
             );
-            let bid_commitment = Point::from_private_affine(composer, bid.c);
+            let bid_commitment = composer.add_affine(bid.c);
             let bid_stealth_addr = (
-                Point::from_private_affine(
-                    composer,
-                    bid.stealth_address.pk_r().as_ref().into(),
-                ),
-                Point::from_private_affine(
-                    composer,
-                    bid.stealth_address.R().into(),
-                ),
+                composer.add_affine(bid.stealth_address.pk_r().as_ref().into()),
+                composer.add_affine(bid.stealth_address.R().into()),
             );
             let eligibility = AllocatedScalar::allocate(
                 composer,
@@ -249,7 +243,7 @@ mod tests {
             composer.constrain_to_constant(
                 bid_hash,
                 BlsScalar::zero(),
-                -storage_bid,
+                Some(-storage_bid),
             );
         };
         // Proving
@@ -262,7 +256,7 @@ mod tests {
         let mut verifier = Verifier::new(b"testing");
         circuit(verifier.mut_cs(), &bid);
         verifier.preprocess(&ck)?;
-        let pi = verifier.mut_cs().public_inputs.clone();
+        let pi = verifier.mut_cs().construct_dense_pi_vec();
         verifier.verify(&proof, &vk, &pi)
     }
 }

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
         use dusk_plonk::prelude::*;
         use num_bigint::BigUint;
         use num_traits::{One, Zero};
-        use poseidon252::sponge;use plonk_gadgets::{
+        use dusk_poseidon::sponge;use plonk_gadgets::{
             AllocatedScalar, RangeGadgets::max_bound, ScalarGadgets::maybe_equal,
 };
     }

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -407,7 +407,10 @@ mod tests {
         let rand_scalar = BlsScalar::random(&mut rand::thread_rng());
         let big_uint = BigUint::from_bytes_le(&rand_scalar.to_bytes());
 
-        assert_eq!(biguint_to_scalar(big_uint).unwrap(), rand_scalar)
+        assert_eq!(
+            biguint_to_scalar(big_uint).expect("BigUint conversion failed"),
+            rand_scalar
+        )
     }
 
     fn allocate_fields(
@@ -542,9 +545,7 @@ mod tests {
             alloc_latest_consensus_step,
         );
         verifier.preprocess(&ck)?;
-        verifier
-            .verify(&proof, &vk, &vec![BlsScalar::zero()])
-            .map_err(|e| e.into())
+        Ok(verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])?)
     }
 
     #[test]

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -124,7 +124,7 @@ impl Score {
         secret: &JubJubAffine,
         secret_k: BlsScalar,
         bid_tree_root: BlsScalar,
-        consensus_round_seed: u64,
+        consensus_round_seed: BlsScalar,
         latest_consensus_round: u64,
         latest_consensus_step: u64,
     ) -> Result<Score, BlindBidError> {
@@ -132,7 +132,6 @@ impl Score {
             return Err(BlindBidError::ExpiredBid);
         };
 
-        let consensus_round_seed = BlsScalar::from(consensus_round_seed);
         let latest_consensus_round = BlsScalar::from(latest_consensus_round);
         let latest_consensus_step = BlsScalar::from(latest_consensus_step);
 
@@ -471,7 +470,7 @@ mod tests {
         // Generate fields for the Bid & required by the compute_score
         let secret_k = BlsScalar::random(&mut rand::thread_rng());
         let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
-        let consensus_round_seed = 3u64;
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         // Set latest consensus round as the max value so the score gen does not
         // fail for that but for the proof verification error if that's
         // the case
@@ -570,7 +569,7 @@ mod tests {
         // Generate fields for the Bid & required by the compute_score
         let secret_k = BlsScalar::random(&mut rand::thread_rng());
         let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
-        let consensus_round_seed = 5u64;
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         // Set the timestamps to the maximum possible value so the generation of
         // the score does not fail for that reason but for the proof
         // verification.

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -17,9 +17,10 @@ cfg_if::cfg_if! {
         use dusk_plonk::prelude::*;
         use num_bigint::BigUint;
         use num_traits::{One, Zero};
-        use dusk_poseidon::sponge;use plonk_gadgets::{
+        use dusk_poseidon::sponge;
+        use plonk_gadgets::{
             AllocatedScalar, RangeGadgets::max_bound, ScalarGadgets::maybe_equal,
-};
+        };
     }
 }
 
@@ -370,7 +371,7 @@ fn biguint_to_scalar(biguint: BigUint) -> Result<BlsScalar, BlindBidError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::Result;
+    use crate::BlindBidError;
     use dusk_bytes::Serializable;
     use dusk_pki::{PublicSpendKey, SecretSpendKey};
     use dusk_plonk::jubjub::GENERATOR_EXTENDED;
@@ -446,7 +447,7 @@ mod tests {
     }
 
     #[test]
-    fn correct_score_gen_proof() -> Result<(), Error> {
+    fn correct_score_gen_proof() -> Result<(), BlindBidError> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
@@ -541,11 +542,13 @@ mod tests {
             alloc_latest_consensus_step,
         );
         verifier.preprocess(&ck)?;
-        verifier.verify(&proof, &vk, &vec![BlsScalar::zero()])
+        verifier
+            .verify(&proof, &vk, &vec![BlsScalar::zero()])
+            .map_err(|e| e.into())
     }
 
     #[test]
-    fn incorrect_score_gen_proof() -> Result<()> {
+    fn incorrect_score_gen_proof() -> Result<(), BlindBidError> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -228,7 +228,7 @@ impl Score {
             two_pow_128,
             -BlsScalar::one(),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // 3.(r1 < |Fr|/2^128 AND Y' < 2^128) OR (r1 = |Fr|/2^128 AND Y' < |Fr|
         // mod 2^128).
@@ -269,7 +269,7 @@ impl Score {
             first_cond,
             second_cond,
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // (r1 = |Fr|/2^128 AND Y' < |Fr| mod 2^128)
         let right_assign = composer.mul(
@@ -277,7 +277,7 @@ impl Score {
             third_cond,
             fourth_cond,
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // left_assign XOR right_assign = 1
         // This is possible since condition 1. and 3. are mutually exclusive.
@@ -295,7 +295,7 @@ impl Score {
             BlsScalar::one(),
             BlsScalar::zero(),
             -BlsScalar::one(),
-            BlsScalar::zero(),
+            None,
         );
 
         // 4. r2 < Y'
@@ -303,7 +303,7 @@ impl Score {
             (BlsScalar::one(), r2.var),
             (-BlsScalar::one(), y_prime.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         let r2_min_y_prime_scalar = r2.scalar - y_prime.scalar;
         let r2_min_y_prime = AllocatedScalar {
@@ -320,11 +320,7 @@ impl Score {
 
         // Check that the result of the range_proof is indeed 0 to assert it
         // passed.
-        composer.constrain_to_constant(
-            should_be_one.0,
-            BlsScalar::one(),
-            BlsScalar::zero(),
-        );
+        composer.constrain_to_constant(should_be_one.0, BlsScalar::one(), None);
 
         // 5. q < 2^120
         composer.range_gate(score_alloc_scalar.var, 120usize);
@@ -336,14 +332,14 @@ impl Score {
             score_alloc_scalar.var,
             y_prime.var,
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // q*Y' + r2
         let left = composer.add(
             (BlsScalar::one(), f_y_prime_prod),
             (BlsScalar::one(), r2.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         // (q*Y' + r2) - v*2^128 = 0
         composer.add_gate(
@@ -354,7 +350,7 @@ impl Score {
             -two_pow_128,
             BlsScalar::zero(),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
 
         score_alloc_scalar.var
@@ -392,7 +388,7 @@ mod tests {
         let stealth_addr = pk_r.gen_stealth_address(&secret);
         let secret = GENERATOR_EXTENDED * secret;
         let value: u64 = (&mut rand::thread_rng())
-            .gen_range(crate::V_RAW_MIN, crate::V_RAW_MAX);
+            .gen_range(crate::V_RAW_MIN..crate::V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let eligibility = u64::MAX;
         let expiration = u64::MAX;
@@ -454,7 +450,7 @@ mod tests {
     }
 
     #[test]
-    fn correct_score_gen_proof() -> Result<()> {
+    fn correct_score_gen_proof() -> Result<(), Error> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -4,37 +4,34 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! Score generation
+//! Score generation module
 
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        use crate::errors::BlindBidError;
-        use crate::bid::Bid;
-        use dusk_jubjub::JubJubAffine;
-        use dusk_plonk::prelude::*;
-        use num_bigint::BigUint;
-        use num_traits::{One, Zero};
-        use dusk_poseidon::sponge;
-        use plonk_gadgets::{
-            AllocatedScalar, RangeGadgets::max_bound, ScalarGadgets::maybe_equal,
-        };
-    }
-}
+#[cfg(feature = "std")]
+use {
+    crate::bid::{Bid, BlindBidError},
+    dusk_jubjub::JubJubAffine,
+    num_bigint::BigUint,
+    num_traits::{One, Zero},
+};
 
 use core::ops::Deref;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Serializable};
+use dusk_plonk::constraint_system::{StandardComposer, Variable};
+use dusk_poseidon::sponge;
+use plonk_gadgets::AllocatedScalar;
+use plonk_gadgets::{RangeGadgets::max_bound, ScalarGadgets::maybe_equal};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 /// The `Score` represents a "random" value obtained from the computations
-/// based on blockchain data as well as [Bid](self::Bid) data.
+/// based on blockchain data as well as [Bid](crate::Bid) data.
 /// It derefs to it's value although the structure contains more fields which
 /// are side-results of this computation needed to proof the correctness of the
 /// Score generation process later on.
+#[cfg_attr(feature = "canon", derive(Canon))]
 pub struct Score {
     pub(crate) value: BlsScalar,
     y: BlsScalar,
@@ -95,27 +92,24 @@ impl Score {
     }
 }
 
-#[cfg(feature = "std")]
-pub(self) const SCALAR_FIELD_ORD_DIV_2_POW_128: BlsScalar =
-    BlsScalar::from_raw([
-        0x3339d80809a1d805,
-        0x73eda753299d7d48,
-        0x0000000000000000,
-        0x0000000000000000,
-    ]);
+const SCALAR_FIELD_ORD_DIV_2_POW_128: BlsScalar = BlsScalar::from_raw([
+    0x3339d80809a1d805,
+    0x73eda753299d7d48,
+    0x0000000000000000,
+    0x0000000000000000,
+]);
 
-#[cfg(feature = "std")]
-pub(self) const MINUS_ONE_MOD_2_POW_128: BlsScalar = BlsScalar::from_raw([
+const MINUS_ONE_MOD_2_POW_128: BlsScalar = BlsScalar::from_raw([
     0xffffffff00000000,
     0x53bda402fffe5bfe,
     0x0000000000000000,
     0x0000000000000000,
 ]);
 
-#[cfg(feature = "std")]
 impl Score {
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     /// Given a `Bid`, compute it's Score and return it.
-    #[cfg_attr(docsrs, doc(cfg(feature = "canon")))]
     pub fn compute(
         bid: &Bid,
         secret: &JubJubAffine,
@@ -178,7 +172,6 @@ impl Score {
 
     /// Proves that a `Score` is correctly generated.
     /// Prints the proving statements in the passed Constraint System.
-    #[cfg_attr(docsrs, doc(cfg(feature = "canon")))]
     pub fn prove_correct_score_gadget(
         &self,
         composer: &mut StandardComposer,
@@ -371,10 +364,11 @@ fn biguint_to_scalar(biguint: BigUint) -> Result<BlsScalar, BlindBidError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::BlindBidError;
-    use dusk_bytes::Serializable;
+    use crate::Bid;
     use dusk_pki::{PublicSpendKey, SecretSpendKey};
     use dusk_plonk::jubjub::GENERATOR_EXTENDED;
+    use dusk_plonk::prelude::*;
+    use plonk_gadgets::AllocatedScalar;
     use rand::Rng;
 
     fn random_bid(secret: &JubJubScalar) -> Bid {

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -6,12 +6,8 @@
 
 //! Score generation
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "canon")] {
-        use canonical::Canon;
-        use canonical_derive::Canon;
-    }
-}
+#[cfg(feature = "canon")]
+use canonical_derive::Canon;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {

--- a/src/bid/score.rs
+++ b/src/bid/score.rs
@@ -119,7 +119,7 @@ pub(self) const MINUS_ONE_MOD_2_POW_128: BlsScalar = BlsScalar::from_raw([
 impl Score {
     /// Given a `Bid`, compute it's Score and return it.
     #[cfg_attr(docsrs, doc(cfg(feature = "canon")))]
-    pub fn compute_score(
+    pub fn compute(
         bid: &Bid,
         secret: &JubJubAffine,
         secret_k: BlsScalar,
@@ -478,7 +478,7 @@ mod tests {
         let latest_consensus_step = 2u64;
 
         // Edit score fields which should make the test fail
-        let score = Score::compute_score(
+        let score = Score::compute(
             &bid,
             &secret.into(),
             secret_k,
@@ -577,7 +577,7 @@ mod tests {
         let latest_consensus_step = 2u64;
 
         // Edit score fields which should make the test fail
-        let mut score = Score::compute_score(
+        let mut score = Score::compute(
             &bid,
             &secret.into(),
             secret_k,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,8 @@
 
 use dusk_bytes::Error as DuskBytesError;
 use dusk_jubjub::JubJubScalar;
+use dusk_plonk::error::Error as PlonkError;
+use dusk_poseidon::Error as PoseidonError;
 #[cfg(feature = "std")]
 use std::fmt;
 
@@ -42,6 +44,10 @@ pub enum BlindBidError {
     IOError,
     /// Dusk-bytes serialization error
     SerializationError(DuskBytesError),
+    /// Plonk lib error
+    PlonkError(PlonkError),
+    /// Poseidon lib error
+    PoseidonError(PoseidonError),
 }
 
 #[cfg(feature = "std")]
@@ -64,5 +70,17 @@ impl From<BlindBidError> for std::io::Error {
 impl From<DuskBytesError> for BlindBidError {
     fn from(bytes_err: DuskBytesError) -> Self {
         Self::SerializationError(bytes_err)
+    }
+}
+
+impl From<PlonkError> for BlindBidError {
+    fn from(plonk_err: PlonkError) -> Self {
+        Self::PlonkError(plonk_err)
+    }
+}
+
+impl From<PoseidonError> for BlindBidError {
+    fn from(poseidon_err: PoseidonError) -> Self {
+        Self::PoseidonError(poseidon_err)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,12 +6,11 @@
 
 //! Errors related to the BlindBid module
 
+use core::fmt;
 use dusk_bytes::Error as DuskBytesError;
 use dusk_jubjub::JubJubScalar;
 use dusk_plonk::error::Error as PlonkError;
 use dusk_poseidon::Error as PoseidonError;
-#[cfg(feature = "std")]
-use std::fmt;
 
 #[derive(Debug)]
 /// Compilation of the erros that blindbid procedures might end up producing.
@@ -50,7 +49,6 @@ pub enum BlindBidError {
     PoseidonError(PoseidonError),
 }
 
-#[cfg(feature = "std")]
 impl fmt::Display for BlindBidError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Bid Generation Error: {:?}", &self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,14 +133,17 @@
     html_root_url = "https://docs.rs/dusk-blindbid/0.0.0"
 )]
 
+extern crate alloc;
+
 pub(crate) mod bid;
 pub(crate) mod errors;
-#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "canon")))]
+#[cfg(feature = "canon")]
 pub(crate) mod proof;
 pub use bid::{Bid, Score};
 pub use errors::BlindBidError;
-#[cfg(all(feature = "std", feature = "canon"))]
-#[cfg_attr(docsrs, doc(cfg(all(feature = "canon", feature = "std"))))]
+#[cfg(feature = "canon")]
+#[cfg_attr(docsrs, doc(cfg(feature = "canon")))]
 pub use proof::BlindBidCircuit;
 /// The minimum amount of Dusk an user is permitted to bid.
 pub const V_RAW_MIN: u64 = 50_000u64;

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -70,11 +70,11 @@ use dusk_plonk::constraint_system::ecc::{
     scalar_mul::fixed_base::scalar_mul, Point,
 };
 use dusk_plonk::prelude::*;
-use plonk_gadgets::{AllocatedScalar, RangeGadgets::max_bound};
-use poseidon252::{
+use dusk_poseidon::{
     sponge,
     tree::{merkle_opening as merkle_opening_gadget, PoseidonBranch},
 };
+use plonk_gadgets::{AllocatedScalar, RangeGadgets::max_bound};
 #[cfg(test)]
 mod bid_tests;
 #[cfg(test)]

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -66,9 +66,6 @@ use anyhow::Result;
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_pki::Ownable;
-use dusk_plonk::constraint_system::ecc::{
-    scalar_mul::fixed_base::scalar_mul, Point,
-};
 use dusk_plonk::prelude::*;
 use dusk_poseidon::{
     sponge,
@@ -114,8 +111,6 @@ mod tree_assets;
 ///     latest_consensus_round: BlsScalar::from(latest_consensus_round),
 ///     latest_consensus_step: BlsScalar::from(latest_consensus_step),
 ///     branch: &branch,
-///     trim_size: 1 << 15,
-///     pi_positions: vec![],
 /// };
 /// circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
 /// ```
@@ -138,14 +133,11 @@ pub struct BlindBidCircuit<'a> {
     pub branch: &'a PoseidonBranch<17>,
     /// Secret that derypts the Cipher.
     pub secret: JubJubAffine,
-    /// Trim size of the Public Parameters used by the PLONK mechanism.
-    pub trim_size: usize,
-    /// Positions of the Public Inputs used with the proof.
-    pub pi_positions: Vec<PublicInput>,
 }
 
-impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
-    fn gadget(&mut self, composer: &mut StandardComposer) -> Result<()> {
+impl<'a> Circuit for BlindBidCircuit<'a> {
+    const CIRCUIT_ID: [u8; 32] = [0xff; 32];
+    fn gadget(&mut self, composer: &mut StandardComposer) -> Result<(), Error> {
         // Check if the inputs were indeed pre-loaded inside of the circuit
         // structure.
         let bid = self.bid;
@@ -156,8 +148,6 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         let latest_consensus_step = self.latest_consensus_step;
         let score = self.score;
         let secret = self.secret;
-        // Instantiate PI vector.
-        let pi = self.get_mut_pi_positions();
         // Get the corresponding `StorageBid` value that for the `Bid`
         // which is effectively the value of the proven leaf (hash of the Bid)
         // and allocate it.
@@ -170,17 +160,10 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             composer.add_input(bid.encrypted_data().cipher()[0]),
             composer.add_input(bid.encrypted_data().cipher()[1]),
         );
-        let bid_commitment =
-            Point::from_private_affine(composer, bid.commitment());
+        let bid_commitment = composer.add_affine(bid.commitment());
         let bid_stealth_addr = (
-            Point::from_private_affine(
-                composer,
-                bid.stealth_address().pk_r().as_ref().into(),
-            ),
-            Point::from_private_affine(
-                composer,
-                bid.stealth_address().R().into(),
-            ),
+            composer.add_affine(bid.stealth_address().pk_r().as_ref().into()),
+            composer.add_affine(bid.stealth_address().R().into()),
         );
         let bid_eligibility_ts = AllocatedScalar::allocate(
             composer,
@@ -191,7 +174,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             BlsScalar::from(bid.expiration()),
         );
         let pos =
-            AllocatedScalar::allocate(composer, BlsScalar::from(bid.pos()));
+            AllocatedScalar::allocate(composer, BlsScalar::from(*bid.pos()));
         // Allocate bid-needed inputs
         let secret_k = AllocatedScalar::allocate(composer, secret_k);
         let seed = AllocatedScalar::allocate(composer, seed);
@@ -223,16 +206,15 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         // ------------------------------------------------------- //
 
         // 1. Merkle Opening
-        let root = merkle_opening_gadget(composer, branch, bid_hash.var);
-        // Add PI constraint for the root to the PI constructor
-        pi.push(PublicInput::BlsScalar(
-            -branch.root(),
-            composer.circuit_size(),
-        ));
+        let root = merkle_opening_gadget(composer, branch);
 
         // Constraint the bid_tree_root against a PI that represents
         // the root of the Bid tree that lives inside of the `Bid` contract.
-        composer.constrain_to_constant(root, BlsScalar::zero(), -branch.root());
+        composer.constrain_to_constant(
+            root,
+            BlsScalar::zero(),
+            Some(-branch.root()),
+        );
 
         // 2. Bid pre_image check
         let computed_bid_hash = preimage_gadget(
@@ -246,16 +228,11 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             pos.var,
         );
 
-        // Add PI constraint for bid preimage check.
-        pi.push(PublicInput::BlsScalar(
-            -bid_hash.scalar,
-            composer.circuit_size(),
-        ));
         // Constraint the hash to be equal to the real one
         composer.constrain_to_constant(
             computed_bid_hash,
             BlsScalar::zero(),
-            -bid_hash.scalar,
+            Some(-bid_hash.scalar),
         );
 
         // 3. t_a >= k_t
@@ -264,7 +241,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             (BlsScalar::one(), latest_consensus_round.var),
             (-BlsScalar::one(), bid_eligibility_ts.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         let kt_min_ta_scalar =
             latest_consensus_round.scalar - bid_eligibility_ts.scalar;
@@ -282,11 +259,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         .0;
         // Constraint third condition to be one.
         // So basically, that the rangeproof does not hold.
-        composer.constrain_to_constant(
-            third_cond,
-            BlsScalar::one(),
-            BlsScalar::zero(),
-        );
+        composer.constrain_to_constant(third_cond, BlsScalar::one(), None);
 
         // 4. t_e >= k_t
         // k_t - t_e should be > 2^64 which is the max size of the round.
@@ -294,7 +267,7 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             (BlsScalar::one(), latest_consensus_round.var),
             (-BlsScalar::one(), bid_expiration.var),
             BlsScalar::zero(),
-            BlsScalar::zero(),
+            None,
         );
         let kt_min_te_scalar =
             latest_consensus_round.scalar - bid_expiration.scalar;
@@ -312,22 +285,14 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
         .0;
         // Constraint third condition to be one.
         // So basically, that the rangeproof does not hold.
-        composer.constrain_to_constant(
-            fourth_cond,
-            BlsScalar::one(),
-            BlsScalar::zero(),
-        );
+        composer.constrain_to_constant(fourth_cond, BlsScalar::one(), None);
 
         // 5. c = C(v, b) Pedersen Commitment check
-        let p1 = scalar_mul(composer, bid_value.var, GENERATOR_EXTENDED);
-        let p2 = scalar_mul(composer, bid_blinder.var, GENERATOR_NUMS_EXTENDED);
-        let computed_c = p1.point().fast_add(composer, *p2.point());
-        // Add PI constraint for the commitment computation check.
-        pi.push(PublicInput::AffinePoint(
-            bid.commitment(),
-            composer.circuit_size(),
-            composer.circuit_size() + 1,
-        ));
+        let p1 =
+            composer.fixed_base_scalar_mul(bid_value.var, GENERATOR_EXTENDED);
+        let p2 = composer
+            .fixed_base_scalar_mul(bid_blinder.var, GENERATOR_NUMS_EXTENDED);
+        let computed_c = composer.point_addition_gate(p1, p2);
 
         // Assert computed_commitment == announced commitment.
         composer.assert_equal_public_point(computed_c, bid.commitment());
@@ -338,18 +303,13 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
 
         // 7. `m = H(k)` Secret key pre-image check.
         let secret_k_hash = sponge::gadget(composer, &[secret_k.var]);
-        // Add PI constraint for the secret_k_hash.
-        pi.push(PublicInput::BlsScalar(
-            -bid.hashed_secret(),
-            composer.circuit_size(),
-        ));
 
         // Constraint the secret_k_hash to be equal to the publicly avaliable
         // one.
         composer.constrain_to_constant(
             secret_k_hash,
             BlsScalar::zero(),
-            -bid.hashed_secret(),
+            Some(-bid.hashed_secret()),
         );
 
         // We generate the prover_id and constrain it to a public input
@@ -365,26 +325,15 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             ],
         );
 
-        // Constraint the prover_id to be the public one and set it in the PI
-        // constructor.
-        pi.push(PublicInput::BlsScalar(
-            -bid.generate_prover_id(
-                secret_k.scalar,
-                seed.scalar,
-                latest_consensus_round.scalar,
-                latest_consensus_step.scalar,
-            ),
-            composer.circuit_size(),
-        ));
         composer.constrain_to_constant(
             prover_id,
             BlsScalar::zero(),
-            -bid.generate_prover_id(
+            Some(-bid.generate_prover_id(
                 secret_k.scalar,
                 seed.scalar,
                 latest_consensus_round.scalar,
                 latest_consensus_step.scalar,
-            ),
+            )),
         );
 
         // 9. Score generation circuit check with the corresponding gadget.
@@ -398,33 +347,15 @@ impl<'a> Circuit<'a> for BlindBidCircuit<'a> {
             latest_consensus_step,
         );
 
-        // Constraint the score to be the public one and set it in the PI
-        // constructor.
-        pi.push(PublicInput::BlsScalar(
-            -score.value(),
-            composer.circuit_size(),
-        ));
         composer.constrain_to_constant(
             computed_score,
             BlsScalar::zero(),
-            -score.value(),
+            Some(-score.value()),
         );
         Ok(())
     }
 
-    fn get_pi_positions(&self) -> &Vec<PublicInput> {
-        &self.pi_positions
-    }
-
-    fn get_mut_pi_positions(&mut self) -> &mut Vec<PublicInput> {
-        &mut self.pi_positions
-    }
-
-    fn get_trim_size(&self) -> usize {
-        self.trim_size
-    }
-
-    fn set_trim_size(&mut self, size: usize) {
-        self.trim_size = size;
+    fn padded_circuit_size(&self) -> usize {
+        1 << 15
     }
 }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -62,7 +62,6 @@
 
 use crate::bid::score::Score;
 use crate::bid::{encoding::preimage_gadget, Bid};
-use anyhow::Result;
 use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::{JubJubAffine, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
 use dusk_pki::Ownable;
@@ -91,28 +90,19 @@ mod tree_assets;
 ///
 /// # Example
 /// ```ignore
-/// // Initialize your `PublicInput` Vector.
-/// let pi = vec![
-///     PublicInput::BlsScalar(*branch.root(), 0),
-///     PublicInput::BlsScalar(storage_bid, 0),
-///     PublicInput::AffinePoint(bid.commitment(), 0, 0),
-///     PublicInput::BlsScalar(bid.hashed_secret(), 0),
-///     PublicInput::BlsScalar(prover_id, 0),
-///     PublicInput::BlsScalar(score.value(), 0)];
+/// let (pk, vd) = BlindBidCircuit::default().compile();
+/// // Initialize your `PublicInputValue` Vector.
+/// let pi: Vec<PublicInputValue> = vec![
+///     (*branch.root()).into(),
+///     storage_bid.into(),
+///     bid.commitment().into(),
+///     bid.hashed_secret().into(),
+///     prover_id.into(),
+///     score.value().into(),
+/// ];
 ///
-/// // Create a mutable instance of the BlindBidCircuit and
-/// //
-/// let mut circuit = BlindBidCircuit {
-///     bid,
-///     score: Score::default(),
-///     secret_k: BlsScalar::one(),
-///     secret: JubJubAffine::default(),
-///     seed: BlsScalar::from(consensus_round_seed),
-///     latest_consensus_round: BlsScalar::from(latest_consensus_round),
-///     latest_consensus_step: BlsScalar::from(latest_consensus_step),
-///     branch: &branch,
-/// };
-/// circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
+/// // Assuming we got a proof from somewhere which we want to verify.
+/// circuit::verify_proof(&pub_params, &vd.key(), &proof, &pi, &vd.pi_pos(), b"CorrectnessBid")
 /// ```
 #[cfg_attr(docsrs, doc(cfg(all(feature = "std", feature = "canon"))))]
 #[derive(Debug, Clone)]

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -104,7 +104,7 @@ mod tree_assets;
 /// // Assuming we got a proof from somewhere which we want to verify.
 /// circuit::verify_proof(&pub_params, &vd.key(), &proof, &pi, &vd.pi_pos(), b"CorrectnessBid")
 /// ```
-#[cfg_attr(docsrs, doc(cfg(all(feature = "std", feature = "canon"))))]
+#[cfg_attr(docsrs, doc(cfg(feature = "canon")))]
 #[derive(Debug, Clone)]
 pub struct BlindBidCircuit<'a> {
     /// Bid used to generate the score

--- a/src/proof/bid_tests.rs
+++ b/src/proof/bid_tests.rs
@@ -65,7 +65,7 @@ mod protocol_tests {
         let latest_consensus_step = 50u64;
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -115,16 +115,6 @@ mod protocol_tests {
             score.value().into(),
         ];
 
-        let mut circuit = BlindBidCircuit {
-            bid,
-            score: Score::default(),
-            secret_k: BlsScalar::one(),
-            secret: JubJubAffine::default(),
-            seed: BlsScalar::from(consensus_round_seed),
-            latest_consensus_round: BlsScalar::from(latest_consensus_round),
-            latest_consensus_step: BlsScalar::from(latest_consensus_step),
-            branch: &branch,
-        };
         circuit::verify_proof(
             &pub_params,
             &vd.key(),
@@ -155,7 +145,7 @@ mod protocol_tests {
         let latest_consensus_step = 50u64;
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -241,7 +231,7 @@ mod protocol_tests {
         let latest_consensus_step = 25519u64;
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -338,7 +328,7 @@ mod protocol_tests {
         .expect("Bid creation error");
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =
@@ -443,7 +433,7 @@ mod protocol_tests {
         .expect("Bid creation error");
 
         // Append the Bid to the tree.
-        tree.push(bid.into());
+        tree.push(bid.into()).unwrap();
 
         // Extract the branch
         let branch =

--- a/src/proof/bid_tests.rs
+++ b/src/proof/bid_tests.rs
@@ -74,7 +74,7 @@ mod protocol_tests {
             .expect("Poseidon Branch Extraction");
 
         // Generate a `Score` for our Bid with the consensus parameters
-        let score = Score::compute_score(
+        let score = Score::compute(
             &bid,
             &secret,
             secret_k,
@@ -162,7 +162,7 @@ mod protocol_tests {
             .expect("Poseidon Branch Extraction");
 
         // Generate a `Score` for our Bid with the consensus parameters
-        let mut score = Score::compute_score(
+        let mut score = Score::compute(
             &bid,
             &secret,
             secret_k,
@@ -245,7 +245,7 @@ mod protocol_tests {
             .expect("Poseidon Branch Extraction");
 
         // Generate a `Score` for our Bid with the consensus parameters
-        let score = Score::compute_score(
+        let score = Score::compute(
             &bid,
             &secret,
             secret_k,
@@ -345,7 +345,7 @@ mod protocol_tests {
         let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
 
         // Generate a `Score` for our Bid with the consensus parameters
-        let score = Score::compute_score(
+        let score = Score::compute(
             &bid,
             &secret,
             secret_k,
@@ -448,7 +448,7 @@ mod protocol_tests {
         let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
 
         // Generate a `Score` for our Bid with the consensus parameters
-        let score = Score::compute_score(
+        let score = Score::compute(
             &bid,
             &secret,
             secret_k,

--- a/src/proof/bid_tests.rs
+++ b/src/proof/bid_tests.rs
@@ -61,7 +61,7 @@ mod protocol_tests {
         let bid = random_bid(&secret, secret_k);
         let secret: JubJubAffine = (GENERATOR_EXTENDED * &secret).into();
         // Generate fields for the Bid & required by the compute_score
-        let consensus_round_seed = 2u64;
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_round = 50u64;
         let latest_consensus_step = 50u64;
 
@@ -149,7 +149,7 @@ mod protocol_tests {
         let bid = random_bid(&secret, secret_k);
         let secret: JubJubAffine = (GENERATOR_EXTENDED * &secret).into();
         // Generate fields for the Bid & required by the compute_score
-        let consensus_round_seed = 1u64;
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_round = 50u64;
         let latest_consensus_step = 50u64;
 
@@ -232,7 +232,7 @@ mod protocol_tests {
         let secret: JubJubAffine = (GENERATOR_EXTENDED * &secret).into();
         // Generate fields for the Bid & required by the compute_score
         let bid_tree_root = BlsScalar::random(&mut rand::thread_rng());
-        let consensus_round_seed = 4u64;
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
         let latest_consensus_round = 25519u64;
         let latest_consensus_step = 25519u64;
 
@@ -342,7 +342,7 @@ mod protocol_tests {
         // the score generation would fail since the Bid would be expired.
         let latest_consensus_round = 3u64;
         let latest_consensus_step = 1u64;
-        let consensus_round_seed = 25519u64;
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
 
         // Generate a `Score` for our Bid with the consensus parameters
         let score = Score::compute_score(
@@ -445,7 +445,7 @@ mod protocol_tests {
         // wouldn't be elegible.
         let latest_consensus_round = 3u64;
         let latest_consensus_step = 1u64;
-        let consensus_round_seed = 25519u64;
+        let consensus_round_seed = BlsScalar::random(&mut rand::thread_rng());
 
         // Generate a `Score` for our Bid with the consensus parameters
         let score = Score::compute_score(

--- a/src/proof/bid_tests.rs
+++ b/src/proof/bid_tests.rs
@@ -9,7 +9,6 @@
 use super::tree_assets::BidTree;
 use crate::{Bid, BlindBidCircuit, BlindBidError, Score, V_RAW_MAX, V_RAW_MIN};
 use anyhow::Result;
-use canonical_host::MemStore;
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::jubjub::{JubJubAffine, GENERATOR_EXTENDED};
@@ -24,7 +23,7 @@ fn random_bid(secret: &JubJubScalar, secret_k: BlsScalar) -> Bid {
     ));
     let stealth_addr = pk_r.gen_stealth_address(&secret);
     let secret = GENERATOR_EXTENDED * secret;
-    let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+    let value: u64 = (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
     let value = JubJubScalar::from(value);
     // Set the timestamps as the max values so the proofs do not fail for them
     // (never expired or non-elegible).
@@ -47,13 +46,13 @@ fn random_bid(secret: &JubJubScalar, secret_k: BlsScalar) -> Bid {
 mod protocol_tests {
     use super::*;
     #[test]
-    fn correct_blindbid_proof() -> Result<()> {
+    fn correct_blindbid_proof() -> Result<(), Error> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -69,9 +68,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // Generate a `Score` for our Bid with the consensus parameters
         let score = Score::compute(
@@ -101,22 +99,20 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"CorrectBid")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.commitment(), 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.commitment().into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
 
         let mut circuit = BlindBidCircuit {
@@ -128,10 +124,15 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
-        circuit.verify_proof(&pub_params, &vk, b"CorrectBid", &proof, &pi)
+        circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"CorrectBid",
+        )
     }
 
     #[test]
@@ -141,7 +142,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -157,9 +158,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // Generate a `Score` for our Bid with the consensus parameters
         let mut score = Score::compute(
@@ -192,27 +192,31 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof =
             circuit.gen_proof(&pub_params, &pk, b"BidWithEditedScore")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"BidWithEditedScore", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"BidWithEditedScore"
+        )
+        .is_err());
         Ok(())
     }
 
@@ -223,7 +227,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Generate a correct Bid
         let secret = JubJubScalar::random(&mut rand::thread_rng());
@@ -240,9 +244,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // Generate a `Score` for our Bid with the consensus parameters
         let score = Score::compute(
@@ -275,26 +278,30 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"EditedBidValue")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"EditedBidValue", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"EditedBidValue"
+        )
+        .is_err());
         Ok(())
     }
 
@@ -305,7 +312,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Create an expired bid.
         let mut rng = rand::thread_rng();
@@ -315,7 +322,7 @@ mod protocol_tests {
         let secret = JubJubAffine::from(GENERATOR_EXTENDED * secret);
         let secret_k = BlsScalar::random(&mut rng);
         let value: u64 =
-            (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+            (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let expiration_ts = 100u64;
         let elegibility_ts = 1000u64;
@@ -334,9 +341,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // We first generate the score as if the bid wasn't expired. Otherways
         // the score generation would fail since the Bid would be expired.
@@ -377,26 +383,30 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"ExpiredBid")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"ExpiredBid", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"ExpiredBid"
+        )
+        .is_err());
         Ok(())
     }
 
@@ -407,7 +417,7 @@ mod protocol_tests {
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
 
         // Generate a BidTree and append the Bid.
-        let mut tree = BidTree::<MemStore>::new();
+        let mut tree = BidTree::new();
 
         // Create a non-elegible Bid.
         let mut rng = rand::thread_rng();
@@ -417,7 +427,7 @@ mod protocol_tests {
         let secret = JubJubAffine::from(GENERATOR_EXTENDED * secret);
         let secret_k = BlsScalar::random(&mut rng);
         let value: u64 =
-            (&mut rand::thread_rng()).gen_range(V_RAW_MIN, V_RAW_MAX);
+            (&mut rand::thread_rng()).gen_range(V_RAW_MIN..V_RAW_MAX);
         let value = JubJubScalar::from(value);
         let expiration_ts = 100u64;
         let elegibility_ts = 1000u64;
@@ -436,9 +446,8 @@ mod protocol_tests {
         tree.push(bid.into());
 
         // Extract the branch
-        let branch = tree
-            .poseidon_branch(0usize)
-            .expect("Poseidon Branch Extraction");
+        let branch =
+            tree.branch(0).expect("Poseidon Branch Extraction").unwrap();
 
         // We first generate the score as if the bid was still eligible.
         // Otherways the score generation would fail since the Bid
@@ -480,26 +489,30 @@ mod protocol_tests {
             latest_consensus_round: BlsScalar::from(latest_consensus_round),
             latest_consensus_step: BlsScalar::from(latest_consensus_step),
             branch: &branch,
-            trim_size: 1 << 15,
-            pi_positions: vec![],
         };
 
-        let (pk, vk) = circuit
+        let (pk, vd) = circuit
             .compile(&pub_params)
             .expect("Circuit compilation Error");
         let proof = circuit.gen_proof(&pub_params, &pk, b"NonElegibleBid")?;
         let storage_bid = bid.hash();
-        let pi = vec![
-            PublicInput::BlsScalar(*branch.root(), 0),
-            PublicInput::BlsScalar(storage_bid, 0),
-            PublicInput::AffinePoint(bid.c, 0, 0),
-            PublicInput::BlsScalar(bid.hashed_secret(), 0),
-            PublicInput::BlsScalar(prover_id, 0),
-            PublicInput::BlsScalar(score.value(), 0),
+        let pi: Vec<PublicInputValue> = vec![
+            (*branch.root()).into(),
+            storage_bid.into(),
+            bid.c.into(),
+            bid.hashed_secret().into(),
+            prover_id.into(),
+            score.value().into(),
         ];
-        assert!(circuit
-            .verify_proof(&pub_params, &vk, b"NonElegibleBid", &proof, &pi)
-            .is_err());
+        assert!(circuit::verify_proof(
+            &pub_params,
+            &vd.key(),
+            &proof,
+            &pi,
+            &vd.pi_pos(),
+            b"NonElegibleBid"
+        )
+        .is_err());
         Ok(())
     }
 }

--- a/src/proof/bid_tests.rs
+++ b/src/proof/bid_tests.rs
@@ -8,7 +8,6 @@
 
 use super::tree_assets::BidTree;
 use crate::{Bid, BlindBidCircuit, BlindBidError, Score, V_RAW_MAX, V_RAW_MIN};
-use anyhow::Result;
 use dusk_bytes::Serializable;
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::jubjub::{JubJubAffine, GENERATOR_EXTENDED};
@@ -126,7 +125,7 @@ mod protocol_tests {
     }
 
     #[test]
-    fn edited_score_blindbid_proof() -> Result<()> {
+    fn edited_score_blindbid_proof() -> Result<(), BlindBidError> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
@@ -211,7 +210,7 @@ mod protocol_tests {
     }
 
     #[test]
-    fn edited_bid_value_blindbid_proof() -> Result<()> {
+    fn edited_bid_value_blindbid_proof() -> Result<(), BlindBidError> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
@@ -296,7 +295,7 @@ mod protocol_tests {
     }
 
     #[test]
-    fn expired_bid_proof() -> Result<()> {
+    fn expired_bid_proof() -> Result<(), BlindBidError> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;
@@ -401,7 +400,7 @@ mod protocol_tests {
     }
 
     #[test]
-    fn non_elegible_bid() -> Result<()> {
+    fn non_elegible_bid() -> Result<(), BlindBidError> {
         // Generate Composer & Public Parameters
         let pub_params =
             PublicParameters::setup(1 << 17, &mut rand::thread_rng())?;

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -14,6 +14,7 @@ use dusk_bls12_381::BlsScalar;
 use dusk_poseidon::tree::{
     PoseidonBranch, PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree,
 };
+use microkelvin::Keyed;
 
 #[derive(Debug, Clone, Copy, Canon)]
 pub struct BidLeaf(pub(crate) Bid);
@@ -55,16 +56,13 @@ impl From<BidLeaf> for Bid {
     }
 }
 
-impl<S> PoseidonLeaf<S> for BidLeaf
-where
-    S: Store,
-{
+impl PoseidonLeaf for BidLeaf {
     fn poseidon_hash(&self) -> BlsScalar {
         self.0.hash()
     }
 
     fn pos(&self) -> u64 {
-        self.0.pos()
+        *self.0.pos()
     }
 
     fn set_pos(&mut self, pos: u64) {
@@ -72,37 +70,10 @@ where
     }
 }
 
-pub struct BidTree<S: Store>(
-    PoseidonTree<BidLeaf, PoseidonMaxAnnotation, S, 17usize>,
-);
-
-impl<S> BidTree<S>
-where
-    S: Store,
-{
-    /// Constructor
-    pub fn new() -> Self {
-        Self(PoseidonTree::new())
-    }
-
-    /// Get a bid from a provided index
-    #[allow(dead_code)]
-    pub fn get(&self, idx: u64) -> Option<BidLeaf> {
-        self.0.get(idx as usize).unwrap()
-    }
-
-    /// Append a bid to the tree and return its index
-    ///
-    /// The index will be the last available position
-    pub fn push(&mut self, bid: BidLeaf) -> usize {
-        self.0.push(bid).unwrap()
-    }
-
-    /// Returns a poseidon branch pointing at the specific index
-    pub fn poseidon_branch(
-        &self,
-        idx: usize,
-    ) -> Option<PoseidonBranch<17usize>> {
-        self.0.branch(idx).unwrap()
+impl Keyed<u64> for BidLeaf {
+    fn key(&self) -> &u64 {
+        &self.0.pos()
     }
 }
+
+pub type BidTree = PoseidonTree<BidLeaf, PoseidonMaxAnnotation, 17>;

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -68,7 +68,7 @@ where
     }
 
     fn set_pos(&mut self, pos: u64) {
-        *self.0.set_pos() = pos;
+        self.0.set_pos(pos);
     }
 }
 

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -58,8 +58,8 @@ impl PoseidonLeaf for BidLeaf {
         self.0.hash()
     }
 
-    fn pos(&self) -> u64 {
-        *self.0.pos()
+    fn pos(&self) -> &u64 {
+        self.0.pos()
     }
 
     fn set_pos(&mut self, pos: u64) {

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 #![allow(non_snake_case)]
+#![cfg(feature = "canon")]
 
 use crate::Bid;
 use canonical_derive::Canon;
@@ -73,4 +74,5 @@ impl Keyed<u64> for BidLeaf {
     }
 }
 
+#[allow(dead_code)]
 pub type BidTree = PoseidonTree<BidLeaf, PoseidonMaxAnnotation, 17>;

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -7,13 +7,10 @@
 #![allow(non_snake_case)]
 
 use crate::Bid;
-use canonical::{Canon, Store};
 use canonical_derive::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;
-use dusk_poseidon::tree::{
-    PoseidonBranch, PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree,
-};
+use dusk_poseidon::tree::{PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree};
 use microkelvin::Keyed;
 
 #[derive(Debug, Clone, Copy, Canon)]

--- a/src/proof/tree_assets.rs
+++ b/src/proof/tree_assets.rs
@@ -11,7 +11,7 @@ use canonical::{Canon, Store};
 use canonical_derive::Canon;
 use core::borrow::Borrow;
 use dusk_bls12_381::BlsScalar;
-use poseidon252::tree::{
+use dusk_poseidon::tree::{
     PoseidonBranch, PoseidonLeaf, PoseidonMaxAnnotation, PoseidonTree,
 };
 


### PR DESCRIPTION
Includes the new variants to the `BlindBidError` enum and also the
`From` trait implementations from the respective error types.

Removes the usage of `anyhow` from the crate or the tests and uses always the
crate Error definition for the function signature types.

Resolves: #131

** This should be merged before #130 **